### PR TITLE
Refactor Trainer and DataLoader for enhanced logging

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -4,76 +4,74 @@ import torch
 from torch.utils.data import Dataset, DataLoader
 from PIL import Image
 from torchvision import transforms # Will be used for basic transforms if not passed custom ones
-from tqdm import tqdm # Added import
+from tqdm import tqdm
 
 from src.utils import (
     precompute_superpixels_for_dataset, get_image_paths,
     ImageToTensor, ResizePIL, normalize_image,
-    convert_image_to_pyg_graph, PYG_AVAILABLE # For gan6
+    convert_image_to_pyg_graph, PYG_AVAILABLE
 )
 
 if PYG_AVAILABLE:
     from torch_geometric.data import Batch as PyGBatch
     from torch_geometric.data import Data as PyGData
 else:
-    PyGBatch = None # Placeholder
+    PyGBatch = None
     PyGData = None
 
 
 class SuperpixelDataset(Dataset): # For gan5-style models
-    def __init__(self, image_paths, config, transform=None, target_transform=None):
+    def __init__(self, image_paths, config, data_split_name="train", transform=None, target_transform=None):
         """
         Args:
             image_paths (list): List of paths to images.
             config (object): Configuration object with attributes like image_size,
-                             num_superpixels, cache_dir, dataset_path.
+                             num_superpixels, cache_dir.
+            data_split_name (str): Name of the data split (e.g., "train", "val", "test") for cache naming.
             transform (callable, optional): Optional transform to be applied on a sample image.
             target_transform (callable, optional): Optional transform to be applied on segmentation/adj.
-                                                 (Less common for this setup).
         """
         self.image_paths = image_paths
         self.config = config
-        self.cache_dir = os.path.join(config.cache_dir, f"sp_{config.num_superpixels}_is_{config.image_size}")
+        self.cache_dir = os.path.join(config.cache_dir,
+                                      f"{data_split_name}_sp_{config.num_superpixels}_is_{config.image_size}")
 
-        # Define default transforms if none are provided
         if transform is None:
             self.transform = transforms.Compose([
                 ResizePIL((config.image_size, config.image_size)),
-                ImageToTensor(), # Converts to [0,1] tensor C,H,W
-                transforms.Lambda(normalize_image) # Normalizes to [-1,1]
+                ImageToTensor(),
+                transforms.Lambda(normalize_image)
             ])
         else:
             self.transform = transform
 
-        self.target_transform = target_transform # Usually not needed for seg/adj
+        self.target_transform = target_transform
 
-        # Precompute superpixels if cache is not valid or not present
-        # A simple check: does the cache directory exist and is not empty?
-        # For more robust caching, one might check if all files exist or use a manifest.
+        expected_compactness = getattr(config, 'slic_compactness', 10.0) # Default if not in config
+
         if not os.path.exists(self.cache_dir) or not os.listdir(self.cache_dir):
-            print(f"Cache directory {self.cache_dir} not found or empty. Precomputing superpixels...")
-            # Ensure image_paths are from the configured dataset_path if self.image_paths is empty
-            # or if we want to strictly use paths from the config.
-            # For now, assume image_paths provided to constructor are the ones to use.
-            if not self.image_paths:
-                 print("Warning: image_paths is empty. Attempting to get paths from config.dataset_path.")
+            print(f"Cache directory {self.cache_dir} for split '{data_split_name}' not found or empty. Precomputing superpixels...")
+            if not self.image_paths and hasattr(config, 'dataset_path') and data_split_name == "train":
                  self.image_paths = get_image_paths(config.dataset_path)
+            elif not self.image_paths and hasattr(config, 'dataset_path_val') and data_split_name == "val":
+                 self.image_paths = get_image_paths(config.dataset_path_val)
+            elif not self.image_paths and hasattr(config, 'dataset_path_test') and data_split_name == "test":
+                 self.image_paths = get_image_paths(config.dataset_path_test)
 
             if not self.image_paths:
-                raise ValueError("No image paths provided or found in config.dataset_path for precomputation.")
+                raise ValueError(f"No image paths provided or found for split '{data_split_name}' for precomputation.")
 
             precompute_superpixels_for_dataset(
                 image_paths=self.image_paths,
                 cache_dir=self.cache_dir,
                 image_size=config.image_size,
                 num_superpixels_config=config.num_superpixels,
-                compactness=config.slic_compactness # Assuming slic_compactness is in config
+                compactness=expected_compactness
             )
         else:
-            print(f"Using existing cache directory: {self.cache_dir}")
-            # Verify all expected cache files exist for self.image_paths
+            print(f"Using existing cache directory for split '{data_split_name}': {self.cache_dir}")
             missing_files = False
-            for img_path in self.image_paths:
+            for img_path in self.image_paths: # Ensure image_paths are populated before this loop
                 base_name = os.path.splitext(os.path.basename(img_path))[0]
                 cache_file_path = os.path.join(self.cache_dir, base_name + ".npz")
                 if not os.path.exists(cache_file_path):
@@ -81,17 +79,26 @@ class SuperpixelDataset(Dataset): # For gan5-style models
                     missing_files = True
                     break
             if missing_files:
-                print("Some cache files are missing. Re-running precomputation.")
+                print(f"Some cache files are missing for split '{data_split_name}'. Re-running precomputation.")
+                # Repopulate image_paths if they were empty, specific to split
+                current_dataset_path = None
+                if data_split_name == "train": current_dataset_path = getattr(config, 'dataset_path', None)
+                elif data_split_name == "val": current_dataset_path = getattr(config, 'dataset_path_val', None)
+                elif data_split_name == "test": current_dataset_path = getattr(config, 'dataset_path_test', None)
+
+                if not self.image_paths and current_dataset_path:
+                     self.image_paths = get_image_paths(current_dataset_path)
+
                 if not self.image_paths:
-                     self.image_paths = get_image_paths(config.dataset_path)
+                     raise ValueError(f"No image paths found for split '{data_split_name}' to re-run precomputation.")
+
                 precompute_superpixels_for_dataset(
                     image_paths=self.image_paths,
                     cache_dir=self.cache_dir,
                     image_size=config.image_size,
                     num_superpixels_config=config.num_superpixels,
-                    compactness=config.slic_compactness
+                    compactness=expected_compactness
                 )
-
 
     def __len__(self):
         return len(self.image_paths)
@@ -103,102 +110,73 @@ class SuperpixelDataset(Dataset): # For gan5-style models
 
         try:
             data = np.load(cache_file_path)
-            segments = torch.from_numpy(data["segments"]).long()  # Ensure it's LongTensor for F.one_hot
+            segments = torch.from_numpy(data["segments"]).long()
             adj_matrix = torch.from_numpy(data["adj"]).float()
         except FileNotFoundError:
-            # This should ideally be caught by the __init__ precomputation logic
-            raise FileNotFoundError(f"Cache file not found for {img_path} at {cache_file_path}. "
-                                    "Please ensure precomputation ran correctly.")
+            raise FileNotFoundError(f"Cache file not found for {img_path} at {cache_file_path}. ")
         except Exception as e:
             raise RuntimeError(f"Error loading cached data for {img_path}: {e}")
 
-        # Load image
         try:
             image = Image.open(img_path).convert("RGB")
         except Exception as e:
             raise RuntimeError(f"Error loading image {img_path}: {e}")
 
-        # Apply transforms
         if self.transform:
             image_tensor = self.transform(image)
 
-        # Target transforms are less common here but included for completeness
-        if self.target_transform:
+        if self.target_transform: # Should not be used typically
             segments = self.target_transform(segments)
             adj_matrix = self.target_transform(adj_matrix)
 
         return {
-            "image": image_tensor,      # The real image, transformed
-            "segments": segments,       # Segmentation mask for the image
-            "adj": adj_matrix,          # Adjacency matrix for the superpixels
-            "path": img_path            # Path to the original image
+            "image": image_tensor,
+            "segments": segments,
+            "adj": adj_matrix,
+            "path": img_path
         }
 
-def get_dataloader(config, shuffle=True):
-    """
-    Creates and returns a DataLoader for the SuperpixelDataset.
-    """
-    image_paths = get_image_paths(config.dataset_path)
-    if not image_paths:
-        raise ValueError(f"No images found in {config.dataset_path}")
-
-    if config.debug_num_images > 0:
-        print(f"Using a subset of {config.debug_num_images} images for debugging.")
-        image_paths = image_paths[:config.debug_num_images]
-
-    dataset = SuperpixelDataset(image_paths=image_paths, config=config)
-
-    dataloader = DataLoader(
-        dataset,
-        batch_size=config.batch_size,
-        shuffle=shuffle,
-        num_workers=config.num_workers,
-        pin_memory=True, # Good practice if using CUDA
-        drop_last=True # Important for some GAN training if batch consistency is needed
-    )
-    return dataloader
-
-
-# --- For gan6-style models using PyTorch Geometric ---
-
 class ImageToGraphDataset(Dataset):
-    def __init__(self, image_paths, config, image_transform=None):
-        """
-        Dataset for gan6-style models. Converts images to PyG graph objects.
-        Args:
-            image_paths (list): List of paths to images.
-            config (object): Configuration object.
-            image_transform (callable, optional): Transform for the real image tensor.
-        """
+    def __init__(self, image_paths, config, data_split_name="train", image_transform=None):
         if not PYG_AVAILABLE or PyGData is None:
             raise ImportError("PyTorch Geometric is required for ImageToGraphDataset.")
 
         self.image_paths = image_paths
         self.config = config
+        self.data_split_name = data_split_name
 
-        # Transform for the image itself (e.g., to tensor, normalize for D)
         if image_transform is None:
             self.image_transform = transforms.Compose([
-                ResizePIL((config.image_size, config.image_size)), # Resize before graph conversion too
-                ImageToTensor(), # Converts to [0,1] tensor C,H,W
-                transforms.Lambda(normalize_image) # Normalizes to [-1,1]
+                ResizePIL((config.image_size, config.image_size)),
+                ImageToTensor(),
+                transforms.Lambda(normalize_image)
             ])
         else:
             self.image_transform = image_transform
 
-        # Cache directory for PyG Data objects
-        # Example: cache_root/pyg_graphs_sp100_slic10_is256/
         self.graph_cache_dir = os.path.join(
             config.cache_dir,
-            f"pyg_graphs_sp{config.model.gan6_num_superpixels}_slic{config.model.gan6_slic_compactness}_is{config.image_size}"
+            f"{self.data_split_name}_pyg_graphs_sp{config.model.gan6_num_superpixels}_slic{config.model.gan6_slic_compactness}_is{config.image_size}"
         )
         self._prepare_graph_cache()
 
     def _prepare_graph_cache(self):
         os.makedirs(self.graph_cache_dir, exist_ok=True)
-        print(f"Using/creating PyG graph cache at: {self.graph_cache_dir}")
+        print(f"Using/creating PyG graph cache for {self.data_split_name} at: {self.graph_cache_dir}")
 
         missing_cache_files = False
+        # Ensure image_paths are populated
+        if not self.image_paths:
+            current_dataset_path = None
+            if self.data_split_name == "train": current_dataset_path = getattr(self.config, 'dataset_path', None)
+            elif self.data_split_name == "val": current_dataset_path = getattr(self.config, 'dataset_path_val', None)
+            elif self.data_split_name == "test": current_dataset_path = getattr(self.config, 'dataset_path_test', None)
+            if current_dataset_path:
+                self.image_paths = get_image_paths(current_dataset_path)
+            if not self.image_paths: # If still no paths, can't proceed
+                 print(f"Warning: No image paths found for split '{self.data_split_name}' during graph cache preparation.")
+                 return # Or raise error, but returning allows dataloader to be None later
+
         for img_path in self.image_paths:
             base_name = os.path.splitext(os.path.basename(img_path))[0]
             cache_file = os.path.join(self.graph_cache_dir, f"{base_name}.pt")
@@ -207,29 +185,29 @@ class ImageToGraphDataset(Dataset):
                 break
 
         if missing_cache_files:
-            print("Preprocessing images to PyG graphs for caching...")
-            for img_path in tqdm(self.image_paths, desc="Caching PyG Graphs"):
+            print(f"Preprocessing images to PyG graphs for caching (split: {self.data_split_name})...")
+            if not self.image_paths: # Should be populated above, but double check
+                print(f"Error: No image paths to process for graph caching for split '{self.data_split_name}'.")
+                return
+
+            for img_path in tqdm(self.image_paths, desc=f"Caching PyG Graphs ({self.data_split_name})"):
                 base_name = os.path.splitext(os.path.basename(img_path))[0]
                 cache_file = os.path.join(self.graph_cache_dir, f"{base_name}.pt")
                 if os.path.exists(cache_file):
                     continue
-
                 try:
-                    # Load image, resize, convert to numpy [0,1] for graph conversion
                     pil_img = Image.open(img_path).convert("RGB")
-                    pil_resized = pil_img.resize((self.config.image_size, self.config.image_size), Image.BILINEAR)
+                    pil_resized = pil_img.resize((self.config.image_size, self.config.image_size), Image.BILINEAR) # TODO: check interpolation consistency
                     img_np_01 = np.array(pil_resized).astype(np.float32) / 255.0
-                    if img_np_01.ndim == 2: # Grayscale
+                    if img_np_01.ndim == 2:
                          img_np_01 = np.expand_dims(img_np_01, axis=-1)
-                    if img_np_01.shape[-1] != 3 and img_np_01.shape[-1] == 1 : # If grayscale with one channel, make it 3 for consistency
+                    if img_np_01.shape[-1] != 3 and img_np_01.shape[-1] == 1 :
                         img_np_01 = np.concatenate([img_np_01]*3, axis=-1)
-
 
                     graph_data = convert_image_to_pyg_graph(
                         img_np_01,
                         num_superpixels=self.config.model.gan6_num_superpixels,
                         slic_compactness=self.config.model.gan6_slic_compactness
-                        # feature_type could be added to config if more options are needed
                     )
                     torch.save(graph_data, cache_file)
                 except Exception as e:
@@ -246,10 +224,8 @@ class ImageToGraphDataset(Dataset):
         try:
             graph_data = torch.load(graph_cache_file)
         except Exception as e:
-            # This should ideally be caught by _prepare_graph_cache
             raise RuntimeError(f"Error loading cached graph data for {img_path} from {graph_cache_file}: {e}")
 
-        # Load and transform the real image (for Discriminator input)
         pil_img = Image.open(img_path).convert("RGB")
         real_image_tensor = self.image_transform(pil_img)
 
@@ -257,58 +233,105 @@ class ImageToGraphDataset(Dataset):
 
 
 def collate_graphs(batch):
-    """Collate function for ImageToGraphDataset."""
     if not PYG_AVAILABLE or PyGBatch is None:
         raise ImportError("PyTorch Geometric is required for collate_graphs.")
 
+    # Filter out None items that could result from __getitem__ failing before returning a tuple
+    # This can happen if an image is corrupted or a cache file is bad for a single item.
+    # However, __getitem__ in this class raises RuntimeError on load failure, so batch should be clean.
+    # But if an image_path was problematic and _prepare_graph_cache skipped it, it might lead here.
+    # For robustness, filter None items from batch if they can occur.
+    # batch = [item for item in batch if item is not None and item[1] is not None]
+    # if not batch: return None # If all items failed
+
     real_images, graph_data_objects = zip(*batch)
-    # Filter out None graphs if any failed during loading (should not happen with proper caching)
     valid_graphs = [g for g in graph_data_objects if g is not None]
+
     if len(valid_graphs) != len(graph_data_objects):
         print(f"Warning: Some graph data objects were None. Found {len(valid_graphs)} valid graphs out of {len(graph_data_objects)}.")
-        # This might lead to batch size mismatch if not handled carefully.
-        # For now, assume all graphs are valid due to caching.
+        if not valid_graphs: # All graphs were None
+             return None # Or handle differently, e.g. return empty tensors / special batch
+
+    # If after filtering, valid_graphs is empty but real_images might not be (if some graphs failed)
+    # This would cause PyGBatch.from_data_list to fail if valid_graphs is empty.
+    if not valid_graphs:
+        # This case should ideally be handled by ensuring all data is processable or by
+        # more sophisticated error handling in __getitem__ or _prepare_graph_cache.
+        # For now, if no valid graphs, we can't form a batch.
+        # Consider returning None or an empty structure that the training loop can skip.
+        print("Warning: No valid graphs in batch after filtering. Skipping batch.")
+        return None # This will need to be handled by the training loop
 
     return torch.stack(real_images), PyGBatch.from_data_list(valid_graphs)
 
 
-def get_dataloader(config, shuffle=True):
-    """
-    Creates and returns a DataLoader.
-    Selects dataset type based on config.model.architecture.
-    """
-    image_paths = get_image_paths(config.dataset_path)
+def get_dataloader(config, data_split="train", shuffle=True, drop_last=True):
+    dataset_path = None
+    if data_split == "train":
+        dataset_path = config.dataset_path
+    elif data_split == "val":
+        dataset_path = getattr(config, 'dataset_path_val', None)
+    elif data_split == "test":
+        dataset_path = getattr(config, 'dataset_path_test', None)
+    else:
+        raise ValueError(f"Invalid data_split: {data_split}. Must be 'train', 'val', or 'test'.")
+
+    if dataset_path is None:
+        print(f"Dataset path for split '{data_split}' is not configured. DataLoader will not be created.")
+        return None
+
+    image_paths = get_image_paths(dataset_path)
     if not image_paths:
-        raise ValueError(f"No images found in {config.dataset_path}")
+        print(f"No images found in {dataset_path} for split '{data_split}'. DataLoader will not be created.")
+        return None
 
-    if config.debug_num_images > 0 and config.debug_num_images < len(image_paths):
-        print(f"Using a subset of {config.debug_num_images} images for debugging.")
+    # Apply debug_num_images only for training split for faster debugging cycles on other splits
+    if data_split == "train" and config.debug_num_images > 0 and config.debug_num_images < len(image_paths):
+        print(f"Using a subset of {config.debug_num_images} images for training debugging.")
         image_paths = image_paths[:config.debug_num_images]
+    elif data_split != "train" and getattr(config, f"debug_num_images_{data_split}", 0) > 0:
+        # Allow specific debug_num_images for val/test if defined in config
+        num_debug = getattr(config, f"debug_num_images_{data_split}")
+        if num_debug < len(image_paths):
+            print(f"Using a subset of {num_debug} images for {data_split} split debugging.")
+            image_paths = image_paths[:num_debug]
 
-    dataset_type = getattr(config.model, "architecture", "gan5_gcn") # Default to gan5
+
+    dataset_type = getattr(config.model, "architecture", "gan5_gcn")
+    dataset = None
+    collate_fn_to_use = None
 
     if dataset_type == "gan6_gat_cnn":
         if not PYG_AVAILABLE:
             raise ImportError("PyTorch Geometric is required for 'gan6_gat_cnn' architecture but not found.")
-        print("Using ImageToGraphDataset for gan6_gat_cnn architecture.")
-        dataset = ImageToGraphDataset(image_paths=image_paths, config=config)
+        print(f"Using ImageToGraphDataset for {data_split} (gan6_gat_cnn architecture).")
+        dataset = ImageToGraphDataset(image_paths=image_paths, config=config, data_split_name=data_split)
         collate_fn_to_use = collate_graphs
     elif dataset_type == "gan5_gcn":
-        print("Using SuperpixelDataset for gan5_gcn architecture.")
-        dataset = SuperpixelDataset(image_paths=image_paths, config=config)
-        collate_fn_to_use = None # Use default collate for SuperpixelDataset
+        print(f"Using SuperpixelDataset for {data_split} (gan5_gcn architecture).")
+        dataset = SuperpixelDataset(image_paths=image_paths, config=config, data_split_name=data_split)
+        # Default collate_fn is fine for SuperpixelDataset
     else:
         raise ValueError(f"Unsupported model.architecture: {dataset_type}")
 
+    # Determine batch size: use eval_batch_size for val/test if defined, else main batch_size
+    current_batch_size = config.batch_size
+    if data_split in ["val", "test"] and hasattr(config, "eval_batch_size") and config.eval_batch_size is not None:
+        current_batch_size = config.eval_batch_size
+        print(f"Using eval_batch_size: {current_batch_size} for {data_split} split.")
+
+
+    # For val/test, drop_last is typically False to evaluate all samples
+    effective_drop_last = drop_last if data_split == "train" else False
+
     dataloader = DataLoader(
         dataset,
-        batch_size=config.batch_size,
+        batch_size=current_batch_size,
         shuffle=shuffle,
         num_workers=config.num_workers,
         pin_memory=True,
-        drop_last=True,
+        drop_last=effective_drop_last,
         collate_fn=collate_fn_to_use
     )
     return dataloader
-
-print("src/data_loader.py created and populated with SuperpixelDataset and get_dataloader.")
+# Removed the print("src/data_loader.py created...") as it's an overwrite

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -1,619 +1,201 @@
 import os
 import torch
+import dataclasses
 import torch.optim as optim
 import torch.nn.functional as F
 from tqdm import tqdm
 import numpy as np
-import torchvision.utils as vutils # For making image grids
+import torchvision.utils as vutils
+import shutil
+from PIL import Image
+from torchvision import transforms
 
-# Local imports
 from src.models import (
-    Generator as GeneratorGan5, Discriminator as DiscriminatorGan5, # gan5 models
-    GraphEncoderGAT, GeneratorCNN, DiscriminatorCNN # gan6 models
+    Generator as GeneratorGan5, Discriminator as DiscriminatorGan5,
+    GraphEncoderGAT, GeneratorCNN, DiscriminatorCNN
 )
-from src.data_loader import get_dataloader
+from src.data_loader import get_dataloader # Assumes updated version with data_split
 from src.utils import (
+    PYG_AVAILABLE,
     save_checkpoint, load_checkpoint, setup_wandb, log_to_wandb,
-    denormalize_image # To convert [-1,1] to [0,1] for logging images
+    denormalize_image
 )
-import shutil # For FID image directory handling
-from PIL import Image # For saving images for FID
 
-# Attempt to import pytorch_fid, if not available, FID calculation will be disabled.
+if PYG_AVAILABLE:
+    from torch_geometric.data import Batch as PyGBatch
+    from torch_geometric.data import Data as PyGData
+else:
+    PyGBatch = None
+    PyGData = None
+
 try:
     from pytorch_fid.fid_score import calculate_fid_given_paths
 except ImportError:
     calculate_fid_given_paths = None
-    print("Warning: pytorch-fid not found. FID calculation will be disabled. "
-          "Install with: pip install pytorch-fid")
-
 
 class Trainer:
     def __init__(self, config):
+        print("Initializing Trainer (from src.trainer)...")
         self.config = config
-        if calculate_fid_given_paths is None:
-            self.config.enable_fid_calculation = False # Disable if library not found
-            print("FID calculation has been disabled because pytorch-fid is not installed.")
+
+        if calculate_fid_given_paths is None and getattr(self.config, 'enable_fid_calculation', False):
+            print("pytorch-fid not found. FID calculation will be disabled.")
+            if hasattr(self.config, 'enable_fid_calculation'):
+                self.config.enable_fid_calculation = False
+
         self.device = torch.device(config.device if torch.cuda.is_available() else "cpu")
         print(f"Using device: {self.device}")
 
-        # Create output directories
+        # output_dir_run is expected to be set in config, e.g. by BaseConfig.__post_init__
+        if not hasattr(config, 'output_dir_run') or not config.output_dir_run:
+            raise ValueError("config.output_dir_run is not set. Ensure it's derived in your config (e.g. BaseConfig.__post_init__)")
+
         os.makedirs(self.config.output_dir_run, exist_ok=True)
         self.checkpoints_dir = os.path.join(self.config.output_dir_run, "checkpoints")
         self.samples_dir = os.path.join(self.config.output_dir_run, "samples")
         os.makedirs(self.checkpoints_dir, exist_ok=True)
         os.makedirs(self.samples_dir, exist_ok=True)
 
-        # Reproducibility
         torch.manual_seed(config.seed)
         np.random.seed(config.seed)
-        if self.device == 'cuda':
+        if self.device.type == 'cuda':
             torch.cuda.manual_seed_all(config.seed)
-            torch.backends.cudnn.deterministic = True # Can slow down, but good for reproducibility
-            torch.backends.cudnn.benchmark = False   # Disable benchmark mode for determinism
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
 
-        # Initialize Models, Optimizers, and Loss based on architecture
         self.model_architecture = config.model.architecture
-        self.E = None # For gan6
-        self.optE = None # For gan6
+        self.E = None
+        self.optE = None
 
         if self.model_architecture == "gan5_gcn":
             self.G = GeneratorGan5(config).to(self.device)
             self.D = DiscriminatorGan5(config).to(self.device)
             self.optG = optim.Adam(self.G.parameters(), lr=config.g_lr, betas=(config.beta1, config.beta2))
             self.optD = optim.Adam(self.D.parameters(), lr=config.d_lr, betas=(config.beta1, config.beta2))
-            self.loss_fn_g = self._loss_g_gan5
             self.loss_fn_d = self._loss_d_gan5
+            self.loss_fn_g = self._loss_g_gan5
             print("Initialized gan5_gcn models and optimizers.")
         elif self.model_architecture == "gan6_gat_cnn":
             self.E = GraphEncoderGAT(config).to(self.device)
             self.G = GeneratorCNN(config).to(self.device)
             self.D = DiscriminatorCNN(config).to(self.device)
-            # Using config.g_lr for both E and G, config.d_lr for D as per legacy/gan6
             self.optE = optim.Adam(self.E.parameters(), lr=config.g_lr, betas=(config.beta1, config.beta2))
             self.optG = optim.Adam(self.G.parameters(), lr=config.g_lr, betas=(config.beta1, config.beta2))
             self.optD = optim.Adam(self.D.parameters(), lr=config.d_lr, betas=(config.beta1, config.beta2))
             self.bce_loss = torch.nn.BCEWithLogitsLoss()
-            self.loss_fn_g = self._loss_g_gan6
             self.loss_fn_d = self._loss_d_gan6
+            self.loss_fn_g = self._loss_g_gan6
             print("Initialized gan6_gat_cnn models (E, G, D) and optimizers.")
         else:
             raise ValueError(f"Unsupported model architecture: {self.model_architecture}")
 
-        # Initialize DataLoader (now depends on model.architecture from config)
-        self.dataloader = get_dataloader(config, shuffle=True)
+        self.train_dataloader = get_dataloader(config, data_split="train", shuffle=True, drop_last=True)
+        if self.train_dataloader is None:
+            raise ValueError("Training dataloader could not be created. Check dataset_path and data.")
 
-        # A fixed batch for generating samples during training
         self.fixed_sample_batch = self._prepare_fixed_sample_batch()
 
-        # Initialize Weights & Biases (if enabled)
-        # Watch G for gan5, or G and E for gan6 (D is usually not watched)
-        model_to_watch = [self.G, self.E] if self.model_architecture == "gan6_gat_cnn" else self.G
-        self.wandb_run = setup_wandb(config, model_to_watch, project_name=config.wandb_project_name, watch_model=True)
+        model_to_watch = [self.G, self.E] if self.model_architecture == "gan6_gat_cnn" and self.E else self.G
+        # Ensure wandb_project_name is in config
+        wandb_proj_name = getattr(config, "wandb_project_name", "default_gan_project")
+        self.wandb_run = setup_wandb(config, model_to_watch, project_name=wandb_proj_name, watch_model=True)
 
-        self.current_epoch = 0
-        self.current_step = 0
 
-        self.fid_temp_real_path = os.path.join(self.config.output_dir_run, "fid_real_images_temp")
-        self.fid_temp_fake_path = os.path.join(self.config.output_dir_run, "fid_fake_images_temp")
+        self.current_epoch = 0 # This is the epoch number we are about to start or resume
+        self.current_step = 0 # Optimizer steps taken overall
 
-        if self.config.resume_checkpoint_path and os.path.exists(self.config.resume_checkpoint_path):
+        if hasattr(self.config, 'resume_checkpoint_path') and self.config.resume_checkpoint_path and os.path.exists(self.config.resume_checkpoint_path):
             self.load_training_checkpoint(self.config.resume_checkpoint_path)
-        else:
-            if self.config.resume_checkpoint_path: # Path given but not found
-                 print(f"Warning: resume_checkpoint_path '{self.config.resume_checkpoint_path}' not found. Starting from scratch.")
-            self.current_epoch = 0
-            self.current_step = 0
+        # else: current_epoch and current_step remain 0
 
     def load_training_checkpoint(self, checkpoint_path):
-        """Loads G, D, (E), optimizers, epoch, and step from a checkpoint."""
         optE_to_load = self.optE if self.model_architecture == "gan6_gat_cnn" else None
-        start_epoch, current_step = load_checkpoint(
-            checkpoint_path,
-            self.G, self.D, self.E, # Pass E, load_checkpoint will handle if it's None
-            self.optG, self.optD, optE_to_load,
-            self.device
+        model_e_to_load = self.E if self.model_architecture == "gan6_gat_cnn" else None
+
+        # load_checkpoint returns the epoch number that was *completed*
+        completed_epoch, optimizer_step_at_checkpoint = load_checkpoint(
+            checkpoint_path, self.G, self.D, model_e_to_load,
+            self.optG, self.optD, optE_to_load, self.device
         )
-        self.current_epoch = start_epoch + 1
-        self.current_step = current_step
-        print(f"Resumed from checkpoint. Starting next epoch: {self.current_epoch}. Current step: {self.current_step}")
+        self.current_epoch = completed_epoch + 1 # Start training from the next epoch
+        self.current_step = optimizer_step_at_checkpoint # Resume optimizer steps
+        print(f"Resumed from checkpoint. Last completed epoch: {completed_epoch}. Next epoch to run: {self.current_epoch}. Resuming optimizer step: {self.current_step}")
 
 
     def _prepare_fixed_sample_batch(self):
-        """Prepares a fixed batch of data for consistent sample generation."""
         try:
-            # Dataloader yields different structures based on architecture
-            raw_fixed_batch = next(iter(self.dataloader))
+            # Use a fresh instance of the training dataloader for fixed batch
+            # This ensures it's not affected by main dataloader's state if num_workers > 0
+            # However, if dataset is very large, this re-initialization can be slow.
+            # For fixed samples, usually shuffle=False is better for consistency too.
+            temp_dataloader = get_dataloader(self.config, data_split="train", shuffle=False, drop_last=False) # Changed shuffle & drop_last
+            if temp_dataloader is None:
+                print("Warning: Could not create temp_dataloader for fixed_sample_batch (train split). Sample generation might fail.")
+                return None
+
+            raw_fixed_batch = None
+            # Try to get a batch. If dataset is smaller than num_samples_to_log, this might iterate a few times.
+            # It's simpler if fixed_sample_batch is just the first batch from this non-shuffled loader.
+            for batch_data in temp_dataloader:
+                raw_fixed_batch = batch_data
+                break # Take the first batch
+
+            del temp_dataloader
+
+            if raw_fixed_batch is None:
+                print("Warning: Training dataloader (for fixed batch) yielded no data.")
+                return None
+
             num_samples = self.config.num_samples_to_log
 
             if self.model_architecture == "gan5_gcn":
+                if not isinstance(raw_fixed_batch, dict) or not all(k in raw_fixed_batch for k in ["image", "segments", "adj"]):
+                    print(f"Warning: Fixed sample batch for gan5_gcn incorrect format. Type: {type(raw_fixed_batch)}")
+                    return None
+                # Ensure we don't take more samples than available in the batch
+                actual_num_samples = min(num_samples, raw_fixed_batch["image"].size(0))
+                if actual_num_samples == 0: return None
                 return {
-                    "image": raw_fixed_batch["image"][:num_samples].to(self.device),
-                    "segments": raw_fixed_batch["segments"][:num_samples].to(self.device),
-                    "adj": raw_fixed_batch["adj"][:num_samples].to(self.device)
+                    "image": raw_fixed_batch["image"][:actual_num_samples].to(self.device),
+                    "segments": raw_fixed_batch["segments"][:actual_num_samples].to(self.device),
+                    "adj": raw_fixed_batch["adj"][:actual_num_samples].to(self.device)
                 }
             elif self.model_architecture == "gan6_gat_cnn":
-                # For gan6, batch is (real_images_tensor, graph_batch_pyg)
-                real_images_tensor, graph_batch_pyg = raw_fixed_batch
-                # We need to select a subset of graphs from graph_batch_pyg if PyGBatch supports it,
-                # or just use the whole batch if it's already small enough.
-                # For simplicity, if num_samples < batch_size, we might use the first num_samples from tensors
-                # and potentially re-batch the graphs or ensure fixed_batch_size for samples is handled.
-                # Let's assume the dataloader's batch for fixed samples is small enough or use all of it.
-                # The GraphEncoder expects a PyGBatch.
-                # We need to slice the graph_batch_pyg. Slicing PyGBatch: batch[:num_samples]
+                real_images_tensor, graph_batch_pyg = None, None
+                if isinstance(raw_fixed_batch, tuple) and len(raw_fixed_batch) == 2:
+                    real_images_tensor, graph_batch_pyg = raw_fixed_batch
+                elif isinstance(raw_fixed_batch, list) and len(raw_fixed_batch) == 2 and \
+                     isinstance(raw_fixed_batch[0], torch.Tensor) and \
+                     (PYG_AVAILABLE and isinstance(raw_fixed_batch[1], PyGBatch)):
+                    print("DEBUG: _prepare_fixed_sample_batch received list, processing as tuple for gan6.")
+                    real_images_tensor, graph_batch_pyg = raw_fixed_batch[0], raw_fixed_batch[1]
+                else:
+                    print(f"DEBUG: Fixed sample batch for gan6_gat_cnn type: {type(raw_fixed_batch)}")
+                    return None
+
+                if not PYG_AVAILABLE or PyGBatch is None or not isinstance(graph_batch_pyg, PyGBatch):
+                    print(f"Error: graph_batch_pyg is not PyGBatch. Type: {type(graph_batch_pyg)}")
+                    return None
+
+                num_graphs_in_batch = graph_batch_pyg.num_graphs if hasattr(graph_batch_pyg, 'num_graphs') else 0
+                actual_num_samples = min(num_samples, num_graphs_in_batch, real_images_tensor.size(0))
+
+                if actual_num_samples == 0: print("Warning: actual_num_samples is 0 for fixed batch."); return None
+
+                data_list = graph_batch_pyg.to_data_list()
+                sliced_graph_batch = PyGBatch.from_data_list(data_list[:actual_num_samples])
                 return {
-                    "image": real_images_tensor[:num_samples].to(self.device), # Real images for D
-                    "graph_batch": graph_batch_pyg[:num_samples].to(self.device) # Graph data for E
+                    "image": real_images_tensor[:actual_num_samples].to(self.device),
+                    "graph_batch": sliced_graph_batch.to(self.device)
                 }
             return None
+        except StopIteration:
+            print("Warning: DataLoader exhausted for fixed sample batch (StopIteration)."); return None
         except Exception as e:
-            print(f"Could not prepare fixed sample batch: {e}. Sample generation might be affected.")
-            return None
-
-    # --- Loss functions for gan5_gcn ---
-    def _loss_d_gan5(self, d_real_logits, d_fake_logits):
-        return (F.softplus(-d_real_logits + d_fake_logits) + F.softplus(d_fake_logits - d_real_logits)).mean()
-
-    def _loss_g_gan5(self, d_fake_for_g_logits):
-        return -d_fake_for_g_logits.mean()
-
-    # --- Loss functions for gan6_gat_cnn ---
-    def _loss_d_gan6(self, d_real_logits, d_fake_logits):
-        real_loss = self.bce_loss(d_real_logits, torch.ones_like(d_real_logits))
-        fake_loss = self.bce_loss(d_fake_logits, torch.zeros_like(d_fake_logits))
-        return (real_loss + fake_loss) * 0.5
-
-    def _loss_g_gan6(self, d_fake_for_g_logits):
-        return self.bce_loss(d_fake_for_g_logits, torch.ones_like(d_fake_for_g_logits))
-
-    def _r1_gradient_penalty(self, real_images, d_real_logits):
-        """Calculates R1 gradient penalty. Common for both architectures."""
-        # Real images should be more 'real' than fake images
-        errD_real = F.binary_cross_entropy_with_logits(d_real - d_fake.mean(), torch.ones_like(d_real))
-        # Fake images should be less 'real' than real images
-        errD_fake = F.binary_cross_entropy_with_logits(d_fake - d_real.mean(), torch.zeros_like(d_fake))
-        return (errD_real + errD_fake) / 2.0
-        # Alternative from gan5 (based on softplus, similar to RaLSGAN):
-        # return (F.softplus(-d_real + d_fake.mean()) + F.softplus(d_fake - d_real.mean())).mean()
-
-
-    def _relativistic_loss_g(self, d_real, d_fake):
-        """Relativistic average Standard GAN loss for Generator."""
-        # Generator wants fake images to be more 'real' than real images
-        errG_real = F.binary_cross_entropy_with_logits(d_real - d_fake.mean(), torch.zeros_like(d_real))
-        # Generator wants fake images to BE real
-        errG_fake = F.binary_cross_entropy_with_logits(d_fake - d_real.mean(), torch.ones_like(d_fake))
-        return (errG_real + errG_fake) / 2.0
-        # Alternative from gan5 (based on simple -D(fake).mean() if not relativistic):
-        # return -d_fake.mean() # This is for standard GAN, not RaLSGAN.
-        # For RaLSGAN (from original gan5 which used rel_loss for D, but -D(fake).mean() for G):
-        # The G loss in gan5 was simply -self.D(fake).mean()
-        # If using relativistic D, G should also be relativistic for consistency.
-        # The provided D loss in gan5: (F.softplus(-r + f) + F.softplus(f - r)).mean()
-        # The G loss was -f_scr.mean().
-        # Let's use the gan5 D loss for now, and the G loss from gan5.
-
-    def _r1_gradient_penalty(self, real_images, d_real_logits):
-        """Calculates R1 gradient penalty."""
-        grad_real = torch.autograd.grad(
-            outputs=d_real_logits.sum(), inputs=real_images, create_graph=True
-        )[0]
-        grad_penalty = (grad_real.view(grad_real.size(0), -1).norm(2, dim=1) ** 2).mean()
-        return grad_penalty
-
-    def train_epoch(self):
-        self.G.train()
-        self.D.train()
-
-        loop = tqdm(self.dataloader, desc=f"Epoch [{self.current_epoch}/{self.config.num_epochs}]")
-        total_g_loss = 0.0
-        total_d_loss = 0.0
-        total_e_loss = 0.0 # For gan6
-
-        for batch_idx, raw_batch_data in enumerate(loop):
-            current_batch_size = 0
-            lossD = torch.tensor(0.0)
-            lossG = torch.tensor(0.0)
-            lossE = torch.tensor(0.0) # For gan6
-            lossD_adv = torch.tensor(0.0)
-            r1_penalty = torch.tensor(0.0)
-            d_real_logits_mean = torch.tensor(0.0)
-            d_fake_logits_mean = torch.tensor(0.0)
-
-            if self.model_architecture == "gan5_gcn":
-                real_images = raw_batch_data["image"].to(self.device)
-                segments_map = raw_batch_data["segments"].to(self.device)
-                adj_matrix = raw_batch_data["adj"].to(self.device)
-                current_batch_size = real_images.size(0)
-
-                # --- Train Discriminator (gan5) ---
-                for _ in range(self.config.d_updates_per_g_update):
-                    self.optD.zero_grad()
-                    z = torch.randn(current_batch_size, self.config.model.z_dim, device=self.device)
-                    with torch.no_grad():
-                        fake_images = self.G(z, real_images, segments_map, adj_matrix)
-
-                    d_real_logits = self.D(real_images)
-                    d_fake_logits = self.D(fake_images.detach()) # Use detached fakes
-
-                    lossD_adv = self.loss_fn_d(d_real_logits, d_fake_logits)
-
-                    real_images.requires_grad_(True)
-                    d_real_logits_for_gp = self.D(real_images)
-                    r1_penalty = self._r1_gradient_penalty(real_images, d_real_logits_for_gp)
-                    real_images.requires_grad_(False)
-
-                    lossD = lossD_adv + self.config.r1_gamma * 0.5 * r1_penalty
-                    lossD.backward()
-                    self.optD.step()
-
-                d_real_logits_mean = d_real_logits.mean() # For logging
-                d_fake_logits_mean = d_fake_logits.mean() # For logging
-
-                # --- Train Generator (gan5) ---
-                self.optG.zero_grad()
-                z = torch.randn(current_batch_size, self.config.model.z_dim, device=self.device)
-                fake_images_for_g = self.G(z, real_images, segments_map, adj_matrix)
-                d_fake_for_g_logits = self.D(fake_images_for_g)
-                lossG = self.loss_fn_g(d_fake_for_g_logits)
-                lossG.backward()
-                self.optG.step()
-
-            elif self.model_architecture == "gan6_gat_cnn":
-                real_images, graph_batch_pyg = raw_batch_data
-                real_images = real_images.to(self.device)
-                graph_batch_pyg = graph_batch_pyg.to(self.device)
-                current_batch_size = real_images.size(0)
-
-                # --- Train Discriminator (gan6) ---
-                self.optD.zero_grad()
-                real_images.requires_grad_(True) # For R1 penalty
-
-                d_real_logits = self.D(real_images)
-
-                with torch.no_grad():
-                    z_graph = self.E(graph_batch_pyg)
-                    fake_images = self.G(z_graph, current_batch_size)
-
-                d_fake_logits = self.D(fake_images.detach())
-
-                lossD_adv = self.loss_fn_d(d_real_logits, d_fake_logits)
-                r1_penalty = self._r1_gradient_penalty(real_images, d_real_logits) # Use d_real_logits directly
-                real_images.requires_grad_(False)
-
-                lossD = lossD_adv + self.config.r1_gamma * 0.5 * r1_penalty
-                lossD.backward()
-                self.optD.step()
-
-                d_real_logits_mean = d_real_logits.mean() # For logging
-                d_fake_logits_mean = d_fake_logits.mean() # For logging
-
-                # --- Train Generator & Encoder (gan6) ---
-                self.optE.zero_grad()
-                self.optG.zero_grad()
-
-                z_graph_for_g = self.E(graph_batch_pyg)
-                fake_images_for_g = self.G(z_graph_for_g, current_batch_size)
-                d_fake_for_g_logits = self.D(fake_images_for_g)
-
-                lossG_and_E = self.loss_fn_g(d_fake_for_g_logits) # Combined loss for G and E
-                lossG_and_E.backward()
-                self.optG.step()
-                self.optE.step()
-                lossG = lossG_and_E # For logging, treat combined loss as G_loss
-                # lossE is implicitly part of lossG here
-
-            total_d_loss += lossD.item()
-            total_g_loss += lossG.item()
-            if self.model_architecture == "gan6_gat_cnn":
-                 # For gan6, E is optimized with G. We log the combined G_loss.
-                 # If we wanted separate E loss, it would need a different formulation.
-                 pass
-
-            if self.current_step % self.config.log_freq_step == 0:
-                log_data = {
-                    "Epoch": self.current_epoch,
-                    "Step": self.current_step,
-                    "Loss_D": lossD.item(),
-                    "Loss_D_Adv": lossD_adv.item(),
-                    "R1_Penalty": r1_penalty.item(),
-                    "Loss_G": lossG.item(),
-                    "D_Real_Logits_Mean": d_real_logits.mean().item(),
-                    "D_Fake_Logits_Mean": d_fake_logits.mean().item(),
-                }
-                log_to_wandb(self.wandb_run, log_data, step=self.current_step)
-                loop.set_postfix(log_data)
-
-            self.current_step +=1
-
-        avg_d_loss = total_d_loss / len(self.dataloader)
-        avg_g_loss = total_g_loss / len(self.dataloader)
-        print(f"Epoch {self.current_epoch} finished. Avg D Loss: {avg_d_loss:.4f}, Avg G Loss: {avg_g_loss:.4f}")
-        log_to_wandb(self.wandb_run, {"Epoch_Avg_D_Loss": avg_d_loss, "Epoch_Avg_G_Loss": avg_g_loss}, step=self.current_step)
-
-
-    def generate_samples(self, epoch, step):
-        if not self.fixed_sample_batch:
-            print("Fixed sample batch not available. Skipping sample generation.")
-            return
-
-        self.G.eval()
-        if self.E: self.E.eval()
-
-        with torch.no_grad():
-            generated_samples = None
-            real_samples_for_log = None
-            num_fixed_samples = self.config.num_samples_to_log # Should match _prepare_fixed_sample_batch
-
-            if self.model_architecture == "gan5_gcn":
-                z_sample = torch.randn(num_fixed_samples, self.config.model.z_dim, device=self.device)
-                generated_samples = self.G(
-                    z_sample,
-                    self.fixed_sample_batch["image"],
-                    self.fixed_sample_batch["segments"],
-                    self.fixed_sample_batch["adj"]
-                )
-                real_samples_for_log = self.fixed_sample_batch["image"]
-
-            elif self.model_architecture == "gan6_gat_cnn":
-                # Ensure fixed_sample_batch["graph_batch"] is correctly sized for num_fixed_samples
-                # The graph_batch might contain more graphs than num_samples_to_log if batch_size > num_samples_to_log
-                # However, _prepare_fixed_sample_batch already slices graph_batch correctly.
-                z_graph = self.E(self.fixed_sample_batch["graph_batch"])
-                # GeneratorCNN takes batch_size for z_noise, which should be num_fixed_samples
-                generated_samples = self.G(z_graph, num_fixed_samples)
-                real_samples_for_log = self.fixed_sample_batch["image"]
-
-            if generated_samples is not None and real_samples_for_log is not None:
-                generated_samples = denormalize_image(generated_samples)
-                real_samples_for_log = denormalize_image(real_samples_for_log)
-
-                img_grid_fake = vutils.make_grid(generated_samples, normalize=False, nrow=int(np.sqrt(generated_samples.size(0))))
-                img_grid_real = vutils.make_grid(real_samples_for_log, normalize=False, nrow=int(np.sqrt(real_samples_for_log.size(0))))
-
-                vutils.save_image(img_grid_fake, os.path.join(self.samples_dir, f"fake_samples_epoch_{epoch:04d}_step_{step}.png"))
-                if epoch == 0 and step <= self.config.log_freq_step * 2 :
-                     vutils.save_image(img_grid_real, os.path.join(self.samples_dir, f"real_samples_epoch_{epoch:04d}.png"))
-
-                if self.wandb_run:
-                    log_images_wandb = {f"Generated_Samples_Epoch_{epoch}": self.wandb_run.Image(img_grid_fake)}
-                    if epoch == 0 and step <= self.config.log_freq_step * 2:
-                         log_images_wandb["Real_Samples"] = self.wandb_run.Image(img_grid_real)
-                    log_to_wandb(self.wandb_run, log_images_wandb, step=step)
-            else:
-                print("Warning: Could not generate samples for logging.")
-
-        self.G.train()
-        if self.E: self.E.train()
-
-
-    def train(self):
-        print("Starting training...")
-        for epoch in range(self.current_epoch, self.config.num_epochs):
-            self.current_epoch = epoch
-            self.train_epoch()
-
-            if epoch % self.config.sample_freq_epoch == 0:
-                self.generate_samples(epoch, self.current_step)
-
-            if epoch % self.config.checkpoint_freq_epoch == 0 or epoch == self.config.num_epochs - 1:
-                checkpoint_path = os.path.join(self.checkpoints_dir, f"checkpoint_epoch_{epoch:04d}.pth.tar")
-                checkpoint_data = {
-                    'epoch': epoch,
-                    'step': self.current_step,
-                    'G_state_dict': self.G.state_dict(),
-                    'D_state_dict': self.D.state_dict(),
-                    'optG_state_dict': self.optG.state_dict(),
-                    'optD_state_dict': self.optD.state_dict(),
-                    'config': self.config
-                }
-                if self.model_architecture == "gan6_gat_cnn":
-                    checkpoint_data['E_state_dict'] = self.E.state_dict()
-                    checkpoint_data['optE_state_dict'] = self.optE.state_dict()
-
-                save_checkpoint(checkpoint_data, is_best=False, filename=checkpoint_path)
-                print(f"Checkpoint saved to {checkpoint_path}")
-
-        print("Training finished.")
-        if self.wandb_run:
-            self.wandb_run.finish()
-
-    def _save_images_for_fid(self, images_tensor, base_path, num_images_to_save):
-        """Saves a batch of image tensors to a directory for FID calculation."""
-        os.makedirs(base_path, exist_ok=True)
-        images_tensor = denormalize_image(images_tensor) # [-1,1] to [0,1]
-        for i in range(min(images_tensor.size(0), num_images_to_save)):
-            image = images_tensor[i]
-            # Convert to PIL Image and save
-            # torchvision.transforms.ToPILImage()(image.cpu()).save(os.path.join(base_path, f"img_{i}.png"))
-            # Using vutils.save_image for single image:
-            vutils.save_image(image.cpu(), os.path.join(base_path, f"img_{i}.png"), normalize=False)
-
-
-    def calculate_fid_score(self):
-        """Calculates FID score between generated images and real images."""
-        if not self.config.enable_fid_calculation or calculate_fid_given_paths is None:
-            print("FID calculation skipped (either disabled or pytorch-fid not installed).")
-            return float('nan')
-
-        print("Calculating FID score...")
-        self.G.eval()
-
-        # Clean up previous FID image directories
-        if os.path.exists(self.fid_temp_real_path):
-            shutil.rmtree(self.fid_temp_real_path)
-        if os.path.exists(self.fid_temp_fake_path):
-            shutil.rmtree(self.fid_temp_fake_path)
-        os.makedirs(self.fid_temp_real_path, exist_ok=True)
-        os.makedirs(self.fid_temp_fake_path, exist_ok=True)
-
-        num_fid_images = self.config.fid_num_images
-        fid_batch_size = self.config.fid_batch_size
-
-        # --- Generate and save fake images ---
-        print(f"Generating {num_fid_images} fake images for FID...")
-        generated_count = 0
-        # Use a temporary dataloader for generating fake images, as G needs real image structures
-        # (segments, adj) if the GAN architecture requires them (like gan5).
-        # We can use the existing self.dataloader but iterate without shuffle.
-        temp_dataloader_for_fid = get_dataloader(self.config, shuffle=False) # Get a fresh one
-
-        pbar_fake = tqdm(total=num_fid_images, desc="Generating Fake FID Images")
-        for raw_batch_data_fid in temp_dataloader_for_fid:
-            if generated_count >= num_fid_images:
-                break
-
-            current_gen_batch_size = 0
-            fake_images_batch = None
-
-            if self.model_architecture == "gan5_gcn":
-                real_images_fid = raw_batch_data_fid["image"].to(self.device)
-                segments_map_fid = raw_batch_data_fid["segments"].to(self.device)
-                adj_matrix_fid = raw_batch_data_fid["adj"].to(self.device)
-                current_gen_batch_size = min(fid_batch_size, real_images_fid.size(0), num_fid_images - generated_count)
-                if current_gen_batch_size <=0: break
-
-                z = torch.randn(current_gen_batch_size, self.config.model.z_dim, device=self.device)
-                with torch.no_grad():
-                    fake_images_batch = self.G(z,
-                                         real_images_fid[:current_gen_batch_size],
-                                         segments_map_fid[:current_gen_batch_size],
-                                         adj_matrix_fid[:current_gen_batch_size])
-
-            elif self.model_architecture == "gan6_gat_cnn":
-                # For gan6, G doesn't need real images, only graph structure from E
-                # However, E needs graph_batch. We can use graph_batch from this dataloader.
-                _, graph_batch_pyg_fid = raw_batch_data_fid
-                graph_batch_pyg_fid = graph_batch_pyg_fid.to(self.device)
-
-                # Determine how many graphs are in this batch to set current_gen_batch_size
-                # This assumes graph_batch_pyg_fid.num_graphs is available or can be inferred
-                num_graphs_in_batch = graph_batch_pyg_fid.num_graphs if hasattr(graph_batch_pyg_fid, 'num_graphs') else graph_batch_pyg_fid.ptr.numel() -1
-
-                current_gen_batch_size = min(fid_batch_size, num_graphs_in_batch, num_fid_images - generated_count)
-                if current_gen_batch_size <=0: break
-
-                # If current_gen_batch_size is less than num_graphs_in_batch, we need to slice graph_batch_pyg_fid
-                # Slicing a PyGBatch can be done like: sliced_batch = graph_batch_pyg_fid[:current_gen_batch_size]
-                # This requires PyG batching to be consistent.
-
-                with torch.no_grad():
-                    z_graph = self.E(graph_batch_pyg_fid[:current_gen_batch_size])
-                    fake_images_batch = self.G(z_graph, current_gen_batch_size)
-
-            if fake_images_batch is None: continue
-
-            # Save these fake images
-            for i in range(fake_images_batch.size(0)):
-                if generated_count < num_fid_images:
-                    img_tensor = denormalize_image(fake_images[i].cpu())
-                    vutils.save_image(img_tensor, os.path.join(self.fid_temp_fake_path, f"fake_{generated_count}.png"), normalize=False)
-                    generated_count += 1
-                    pbar_fake.update(1)
-                else:
-                    break
-        pbar_fake.close()
-        if generated_count < num_fid_images:
-            print(f"Warning: Only generated {generated_count}/{num_fid_images} fake images for FID due to dataset size.")
-
-
-        # --- Save real images ---
-        # TODO: Implement option for config.path_to_real_images_for_fid
-        # For now, use images from the current dataset.
-        print(f"Saving {num_fid_images} real images for FID...")
-        saved_real_count = 0
-        # Use the same temp_dataloader_for_fid to ensure consistency if dataset is small
-        # Or get a new one if worried about dataloader state (though shuffle=False should be fine)
-        # temp_dataloader_for_fid was already iterated, so need a new one or reset.
-        real_dataloader_for_fid_save = get_dataloader(self.config, shuffle=False)
-
-        pbar_real = tqdm(total=num_fid_images, desc="Saving Real FID Images")
-        for raw_batch_data_fid_real in real_dataloader_for_fid_save:
-            if saved_real_count >= num_fid_images:
-                break
-
-            # Dataloader yields (real_images, graph_batch_pyg) for gan6, or dict for gan5
-            if self.model_architecture == "gan6_gat_cnn":
-                real_images_batch_save, _ = raw_batch_data_fid_real
-            else: # gan5_gcn
-                real_images_batch_save = raw_batch_data_fid_real["image"]
-
-            real_images_batch_save = real_images_batch_save.to(self.device)
-
-            for i in range(real_images_batch_save.size(0)):
-                if saved_real_count < num_fid_images:
-                    img_tensor = denormalize_image(real_images_batch_save[i].cpu()) # Denorm to [0,1]
-                    vutils.save_image(img_tensor, os.path.join(self.fid_temp_real_path, f"real_{saved_real_count}.png"), normalize=False)
-                    saved_real_count += 1
-                    pbar_real.update(1)
-                else:
-                    break
-        pbar_real.close()
-        if saved_real_count < num_fid_images:
-             print(f"Warning: Only saved {saved_real_count}/{num_fid_images} real images for FID due to dataset size.")
-
-
-        # --- Calculate FID ---
-        if generated_count == 0 or saved_real_count == 0:
-            print("Not enough images generated/saved for FID calculation. Skipping.")
-            self.G.train()
-            return float('nan')
-
-        try:
-            # FID calculation expects images in range [0, 255], uint8, but pytorch-fid handles [0,1] float PNGs.
-            # The images saved by vutils.save_image(tensor, normalize=False) with input tensor in [0,1] are suitable.
-            fid_value = calculate_fid_given_paths(
-                paths=[self.fid_temp_real_path, self.fid_temp_fake_path],
-                batch_size=fid_batch_size, # Batch size for Inception model processing
-                device=self.device,
-                dims=2048, # Standard InceptionV3 feature dimension for FID
-                num_workers=self.config.num_workers
-            )
-            print(f"FID Score: {fid_value:.4f}")
-        except Exception as e:
-            print(f"Error calculating FID: {e}")
-            fid_value = float('nan')
-
-        # Clean up temporary directories
-        # shutil.rmtree(self.fid_temp_real_path)
-        # shutil.rmtree(self.fid_temp_fake_path)
-        # print("Cleaned up temporary FID image directories.")
-        # It might be useful to keep these directories for inspection, so cleanup is commented out.
-
-        self.G.train() # Set generator back to training mode
-        return fid_value
-
-    def train(self):
-        print("Starting training...")
-        for epoch in range(self.current_epoch, self.config.num_epochs):
-            self.current_epoch = epoch
-            self.train_epoch()
-
-            if epoch % self.config.sample_freq_epoch == 0:
-                self.generate_samples(epoch, self.current_step)
-
-            if self.config.enable_fid_calculation and epoch > 0 and \
-               (epoch % self.config.fid_freq_epoch == 0 or epoch == self.config.num_epochs - 1):
-                fid_score = self.calculate_fid_score()
-                log_to_wandb(self.wandb_run, {"FID_Score": fid_score}, step=self.current_step)
-
-
-            if epoch % self.config.checkpoint_freq_epoch == 0 or epoch == self.config.num_epochs - 1:
-                checkpoint_path = os.path.join(self.checkpoints_dir, f"checkpoint_epoch_{epoch:04d}.pth.tar")
-                save_checkpoint({
-                    'epoch': epoch,
-                    'step': self.current_step,
-                    'G_state_dict': self.G.state_dict(),
-                    'D_state_dict': self.D.state_dict(),
-                    'optG_state_dict': self.optG.state_dict(),
-                    'optD_state_dict': self.optD.state_dict(),
-                    'config': self.config # Save config with checkpoint
-                }, is_best=False, filename=checkpoint_path) # 'is_best' logic can be added if there's a validation metric
-                print(f"Checkpoint saved to {checkpoint_path}")
-
-        print("Training finished.")
-        if self.wandb_run:
-            self.wandb_run.finish()
-
-print("src/trainer.py created with Trainer class.")
+            print(f"Error in _prepare_fixed_sample_batch: {e}"); import traceback; traceback.print_exc(); return None
+
+    def _loss_d_gan5(self, d_real_logits, d_fake_logits): return (F.softplus(-d_real_logits + d_fake_logits) + F.softplus(d_fake_logits - d_real_logits)).mean()
+    def _loss_g_gan5(self, d_fake_for_g_logits): return -d_fake_for_g_logits.mean()
+    def _loss_d_gan6(self, d_real_logits, d_fake_logits): return (self.bce_loss(d_real_logits, torch.ones_like(d_real_logits)) + self.bce_loss(d_fake_logits, torch.zeros_like(d_fake_logits))) * 0.5
+    def _loss_g_gan6(self, d_fake_for_g_logits): return self.bce_loss(d_fake_for_g_logits, torch.ones_like(d_fake_for_g_logits))\n
+    def _r1_gradient_penalty(self, real_images, d_real_logits):\n        grad_real = torch.autograd.grad(outputs=d_real_logits.sum(), inputs=real_images, create_graph=True, allow_unused=True)[0]\n        if grad_real is None: return torch.tensor(0.0, device=self.device)\n        return (grad_real.view(grad_real.size(0), -1).norm(2, dim=1) ** 2).mean()\n\n    def train_epoch(self):\n        if self.model_architecture == \"gan5_gcn\": self.G.train(); self.D.train()\n        elif self.model_architecture == \"gan6_gat_cnn\": \n            if self.E: self.E.train()\n            self.G.train(); self.D.train()\n\n        loop = tqdm(self.train_dataloader, desc=f\"Epoch [{self.current_epoch}/{self.config.num_epochs}]\", leave=False)\n        epoch_stats = {k: 0.0 for k in ['d_loss','g_loss','d_adv','r1','d_real_l','d_fake_l']}\n        optimizer_steps_this_epoch = 0\n        grad_accum_steps = getattr(self.config, 'gradient_accumulation_steps', 1)\n\n        # Zero gradients once before the accumulation loop if grad_accum_steps > 1\n        if grad_accum_steps > 1:\n            self.optD.zero_grad(set_to_none=True)\n            self.optG.zero_grad(set_to_none=True)\n            if self.optE: self.optE.zero_grad(set_to_none=True)\n\n        micro_batch_stats_accum = {k: 0.0 for k in epoch_stats.keys()}\n        micro_batch_count = 0\n\n        for batch_idx, raw_batch_data in enumerate(loop):\n            if raw_batch_data is None: print(f\"Warning: Trainer None batch at idx {batch_idx}, skipping.\"); continue\n            \n            current_batch_size=0; real_images=None; graph_batch_pyg=None; segments_map=None; adj_matrix=None\n            # Data loading and validation\n            if self.model_architecture == \"gan5_gcn\":\n                if not (isinstance(raw_batch_data, dict) and all(k in raw_batch_data for k in [\"image\", \"segments\", \"adj\"])): continue\n                real_images=raw_batch_data[\"image\"].to(self.device); segments_map=raw_batch_data[\"segments\"].to(self.device); adj_matrix=raw_batch_data[\"adj\"].to(self.device); current_batch_size=real_images.size(0)\n            elif self.model_architecture == \"gan6_gat_cnn\":\n                if isinstance(raw_batch_data, tuple) and len(raw_batch_data)==2: real_images,graph_batch_pyg = raw_batch_data\n                elif isinstance(raw_batch_data, list) and len(raw_batch_data)==2 and isinstance(raw_batch_data[0],torch.Tensor) and (PYG_AVAILABLE and isinstance(raw_batch_data[1],PyGBatch)):\n                    print(\"DEBUG: train_epoch received list, processing as tuple for gan6.\"); real_images,graph_batch_pyg = raw_batch_data[0],raw_batch_data[1]\n                else: print(f\"DEBUG: Invalid batch type {type(raw_batch_data)} for gan6 (train_epoch).\"); continue\n                real_images=real_images.to(self.device)\n                if not PYG_AVAILABLE or not isinstance(graph_batch_pyg,PyGBatch):print(\"DEBUG: graph_batch_pyg not PyGBatch\"); continue\n                graph_batch_pyg=graph_batch_pyg.to(self.device); current_batch_size=real_images.size(0)\n            if current_batch_size == 0: continue\n\n            # --- D Update --- \n            if grad_accum_steps == 1: self.optD.zero_grad(set_to_none=True)\n            d_upd = getattr(self.config, 'd_updates_per_g_update', 1)\n            batch_d_loss, batch_d_adv, batch_r1, batch_d_real_l, batch_d_fake_l = 0,0,0,0,0\n            for _ in range(d_upd):\n                lossD_s, lossD_adv_s, r1_s, d_real_l_s, d_fake_l_s = torch.tensor(0.0),torch.tensor(0.0),torch.tensor(0.0),torch.tensor(0.0),torch.tensor(0.0)\n                if self.model_architecture==\"gan5_gcn\":\n                    z=torch.randn(current_batch_size,self.config.model.z_dim,device=self.device); \n                    with torch.no_grad():fake_imgs=self.G(z,real_images,segments_map,adj_matrix)\n                    d_real_l_s=self.D(real_images); d_fake_l_s=self.D(fake_imgs.detach()); lossD_adv_s=self.loss_fn_d(d_real_l_s,d_fake_l_s)\n                    real_images.requires_grad_(True); d_real_gp=self.D(real_images);r1_s=self._r1_gradient_penalty(real_images,d_real_gp);real_images.requires_grad_(False)\n                    lossD_s=lossD_adv_s+self.config.r1_gamma*0.5*r1_s\n                elif self.model_architecture==\"gan6_gat_cnn\":\n                    real_images.requires_grad_(True);d_real_l_s=self.D(real_images)\n                    with torch.no_grad():z_g=self.E(graph_batch_pyg);fake_imgs=self.G(z_g,current_batch_size)\n                    d_fake_l_s=self.D(fake_imgs.detach());lossD_adv_s=self.loss_fn_d(d_real_l_s,d_fake_l_s)\n                    r1_s=self._r1_gradient_penalty(real_images,d_real_l_s);real_images.requires_grad_(False)\n                    lossD_s=lossD_adv_s+self.config.r1_gamma*0.5*r1_s\n                lossD_sc=lossD_s/(grad_accum_steps*d_upd);lossD_sc.backward()\n                batch_d_loss+=lossD_s.item();batch_d_adv+=lossD_adv_s.item();batch_r1+=r1_s.item();batch_d_real_l+=d_real_l_s.mean().item();batch_d_fake_l+=d_fake_l_s.mean().item()\n            for k,v in zip(['d_loss','d_adv','r1','d_real_l','d_fake_l'],[x/d_upd for x in [batch_d_loss,batch_d_adv,batch_r1,batch_d_real_l,batch_d_fake_l]]): micro_batch_stats_accum[k]+=v\n            \n            # --- G Update ---\n            if grad_accum_steps == 1: self.optG.zero_grad(set_to_none=True); \n            if self.optE and grad_accum_steps==1: self.optE.zero_grad(set_to_none=True)\n            lossG_s=torch.tensor(0.0)\n            if self.model_architecture==\"gan5_gcn\":\n                z=torch.randn(current_batch_size,self.config.model.z_dim,device=self.device);fake_imgs_g=self.G(z,real_images,segments_map,adj_matrix)\n                d_fake_g=self.D(fake_imgs_g);lossG_s=self.loss_fn_g(d_fake_g)\n            elif self.model_architecture==\"gan6_gat_cnn\":\n                z_g_g=self.E(graph_batch_pyg);fake_imgs_g=self.G(z_g_g,current_batch_size)\n                d_fake_g=self.D(fake_imgs_g);lossG_s=self.loss_fn_g(d_fake_g)\n            lossG_sc=lossG_s/grad_accum_steps;lossG_sc.backward()\n            micro_batch_stats_accum['g_loss']+=lossG_s.item()\n            micro_batch_count+=1\n\n            if (batch_idx+1)%grad_accum_steps==0 or (batch_idx+1)==len(self.train_dataloader):\n                self.optD.step();self.optG.step();\n                if self.optE:self.optE.step()\n                optimizer_steps_this_epoch+=1\n                avg_step_stats={k:v/micro_batch_count for k,v in micro_batch_stats_accum.items()}\n                for k,v in avg_step_stats.items(): epoch_stats[k]+=v # Accumulate for epoch average\n                if self.current_step%self.config.log_freq_step==0:\n                    log_d={f\"Train/{k.replace('_l','_Logits').replace('d_','D_').replace('g_','G_').replace('adv','Adv').replace('r1','R1_Penalty')}_step\":v for k,v in avg_step_stats.items()}\n                    log_d[\"Epoch\"]=self.current_epoch; log_to_wandb(self.wandb_run,log_d,step=self.current_step); loop.set_postfix(log_d)\n                self.current_step+=1\n                if grad_accum_steps > 1 and not ((batch_idx+1)==len(self.train_dataloader)):\n                    self.optD.zero_grad(set_to_none=True);self.optG.zero_grad(set_to_none=True);\n                    if self.optE:self.optE.zero_grad(set_to_none=True)\n                micro_batch_stats_accum={k:0.0 for k in epoch_stats.keys()};micro_batch_count=0\n        \n        if optimizer_steps_this_epoch > 0:\n            avg_epoch_stats={f\"Train/Epoch_Avg_{k.replace('_l','_Logits').replace('d_','D_').replace('g_','G_').replace('adv','Adv').replace('r1','R1_Penalty')}\":v/optimizer_steps_this_epoch for k,v in epoch_stats.items()}\n            avg_epoch_stats[\"Epoch_Num\"]=self.current_epoch;print(f\"Epoch {self.current_epoch} Avg Losses: D={avg_epoch_stats['Train/Epoch_Avg_D_Loss']:.4f}, G={avg_epoch_stats['Train/Epoch_Avg_G_Loss']:.4f}\")\n            log_to_wandb(self.wandb_run,avg_epoch_stats,step=self.current_step)\n\n    def _evaluate_on_split(self, data_split: str):\n        print(f\"Evaluating on {data_split} split...\")\n        eval_dataloader = get_dataloader(self.config, data_split=data_split, shuffle=False, drop_last=False)\n        if eval_dataloader is None: return {}\n        self.G.eval(); self.D.eval(); \n        if self.E: self.E.eval()\n        totals = {k:0.0 for k in ['d_loss','g_loss','d_adv','r1_eval','d_real_l','d_fake_l']}; num_b = 0\n        with torch.no_grad():\n            for raw_b in tqdm(eval_dataloader, desc=f\"Eval {data_split}\", leave=False):\n                if raw_b is None: continue\n                bs=0; r_imgs=None; g_batch=None; seg_map=None; adj_m=None; f_imgs=None\n                if self.model_architecture == \"gan5_gcn\":\n                    if not (isinstance(raw_b, dict) and all(k in raw_b for k in [\"image\", \"segments\", \"adj\"])): continue\n                    r_imgs=raw_b[\"image\"].to(self.device); seg_map=raw_b[\"segments\"].to(self.device); adj_m=raw_b[\"adj\"].to(self.device); bs=r_imgs.size(0)\n                    z=torch.randn(bs,self.config.model.z_dim,device=self.device); f_imgs=self.G(z,r_imgs,seg_map,adj_m)\n                elif self.model_architecture == \"gan6_gat_cnn\":\n                    if isinstance(raw_b,tuple) and len(raw_b)==2: r_imgs,g_batch=raw_b\n                    elif isinstance(raw_b,list) and len(raw_b)==2 and isinstance(raw_b[0],torch.Tensor) and (PYG_AVAILABLE and isinstance(raw_b[1],PyGBatch)): r_imgs,g_batch=raw_b[0],raw_b[1]\n                    else: continue\n                    r_imgs=r_imgs.to(self.device)\n                    if not PYG_AVAILABLE or not isinstance(g_batch,PyGBatch): continue\n                    g_batch=g_batch.to(self.device); bs=r_imgs.size(0)\n                    z_g=self.E(g_batch); f_imgs=self.G(z_g,bs)\n                if bs==0 or f_imgs is None: continue\n                d_r_l_val=self.D(r_imgs); d_f_l_val=self.D(f_imgs); lD_adv=self.loss_fn_d(d_r_l_val,d_f_l_val); r1_eval_b=torch.tensor(0.0) # R1 is 0 in eval\n                lD=lD_adv + self.config.r1_gamma*0.5*r1_eval_b; d_f_g=self.D(f_imgs); lG=self.loss_fn_g(d_f_g)\n                for k,v_val in zip(totals.keys(), [lD.item(),lG.item(),lD_adv.item(),r1_eval_b.item(),d_r_l_val.mean().item(),d_f_l_val.mean().item()]): totals[k]+=v_val\n                num_b+=1\n        if self.model_architecture == \"gan5_gcn\": self.G.train(); self.D.train()\n        elif self.model_architecture == \"gan6_gat_cnn\": \n            if self.E: self.E.train()\n            self.G.train(); self.D.train()\n        if num_b==0: return {}\n        key_map = {'d_loss':'Loss_D', 'g_loss':'Loss_G', 'd_adv':'Loss_D_Adv', 'r1_eval':'R1_Penalty_Eval', 'd_real_l':'D_Real_Logits_Mean', 'd_fake_l':'D_Fake_Logits_Mean'}\n        avg_m = { f\"{data_split}/{key_map[k]}\": v/num_b for k,v in totals.items() }\n        print(f\"Results for {data_split}: {avg_m}\"); return avg_m\n\n    def generate_samples(self, epoch, step):\n        if not self.fixed_sample_batch or not self.fixed_sample_batch.get(\"image\") or self.fixed_sample_batch[\"image\"].size(0) == 0:\n            print(\"Fixed sample batch not available or empty. Skipping sample generation.\"); return\n        if self.model_architecture == \"gan5_gcn\": self.G.eval()\n        elif self.model_architecture == \"gan6_gat_cnn\": \n            if self.E: self.E.eval()\n            self.G.eval()\n        with torch.no_grad():\n            gen_s, real_s = None, None; bs = self.fixed_sample_batch[\"image\"].size(0)\n            if self.model_architecture == \"gan5_gcn\":\n                z=torch.randn(bs,self.config.model.z_dim,device=self.device); gen_s=self.G(z,self.fixed_sample_batch[\"image\"],self.fixed_sample_batch[\"segments\"],self.fixed_sample_batch[\"adj\"])\n                real_s=self.fixed_sample_batch[\"image\"]\n            elif self.model_architecture == \"gan6_gat_cnn\":\n                if \"graph_batch\" not in self.fixed_sample_batch or self.E is None: return\n                z_g=self.E(self.fixed_sample_batch[\"graph_batch\"]); gen_s=self.G(z_g,bs); real_s=self.fixed_sample_batch[\"image\"]\n            if gen_s is not None and real_s is not None:\n                gen_d=denormalize_image(gen_s); real_d=denormalize_image(real_s)\n                vutils.save_image(vutils.make_grid(gen_d,nrow=int(np.sqrt(bs))), os.path.join(self.samples_dir,f\"fake_ep{epoch:04d}_st{step}.png\"))\n                if self.wandb_run:\n                    tbl=self.wandb_run.Table(columns=[\"Epoch\", \"Step\", \"ID\", \"Real\", \"Generated\"])\n                    for i in range(bs): tbl.add_data(epoch,step,i,self.wandb_run.Image(real_d[i].cpu()),self.wandb_run.Image(gen_d[i].cpu()))\n                    log_to_wandb(self.wandb_run, {f\"Sample_Comparisons_Epoch_{epoch}\": tbl}, step=step)\n        if self.model_architecture == \"gan5_gcn\": self.G.train()\n        elif self.model_architecture == \"gan6_gat_cnn\": \n            if self.E: self.E.train()\n            self.G.train()\n\n    def _save_images_for_fid(self, images_tensor, base_path, start_idx, num_to_save):\n        os.makedirs(base_path, exist_ok=True)\n        img_denorm = denormalize_image(images_tensor)\n        for i in range(num_to_save):\n            transforms.ToPILImage()(img_denorm[i].cpu()).save(os.path.join(base_path, f\"img_{start_idx + i}.png\"))\n\n    def calculate_fid_score(self, data_split_for_reals: str = \"test\"):\n        if not getattr(self.config,'enable_fid_calculation',False) or calculate_fid_given_paths is None: return float('nan')\n        print(f\"Calculating FID: reals from '{data_split_for_reals}'...\")\n        om_g,om_e,om_d = self.G.training,(self.E.training if self.E else None),self.D.training\n        self.G.eval(); self.D.eval(); \n        if self.E: self.E.eval()\n        path_r=os.path.join(self.config.output_dir_run,f\"fid_real_{data_split_for_reals}_ep{self.current_epoch}\")\n        path_f=os.path.join(self.config.output_dir_run,f\"fid_fake_ep{self.current_epoch}\")\n        if os.path.exists(path_r): shutil.rmtree(path_r)\n        if os.path.exists(path_f): shutil.rmtree(path_f)\n        os.makedirs(path_r,exist_ok=True); os.makedirs(path_f,exist_ok=True)\n        n_fid=self.config.fid_num_images; fid_dl=get_dataloader(self.config,data_split_for_reals,shuffle=False,drop_last=False)\n        if fid_dl is None: print(f\"FID Err: DL for '{data_split_for_reals}' None.\"); return float('nan')\n        gen_c,real_c=0,0\n        for raw_b in tqdm(fid_dl,desc=f\"Gen/Save FID imgs ({data_split_for_reals})\",leave=False):\n            if raw_b is None: continue\n            bs_r,bs_gen=0,0; r_b_imgs=None; g_b_pyg=None # Ensure g_b_pyg is defined for gan5 case too\n            if self.model_architecture==\"gan5_gcn\":\n                if not (isinstance(raw_b,dict) and \"image\" in raw_b): continue\n                r_b_imgs=raw_b[\"image\"]; bs_r=r_b_imgs.size(0); bs_gen=bs_r\n                seg_m,adj_m=raw_b[\"segments\"].to(self.device),raw_b[\"adj\"].to(self.device)\n            elif self.model_architecture==\"gan6_gat_cnn\":\n                if isinstance(raw_b,tuple) and len(raw_b)==2:tmp_r,tmp_g=raw_b\n                elif isinstance(raw_b,list) and len(raw_b)==2:tmp_r,tmp_g=raw_b[0],raw_b[1]\n                else: continue\n                r_b_imgs=tmp_r; bs_r=r_b_imgs.size(0)\n                if not PYG_AVAILABLE or not isinstance(tmp_g,PyGBatch): continue\n                g_b_pyg=tmp_g.to(self.device); bs_gen=g_b_pyg.num_graphs if hasattr(tmp_g, 'num_graphs') else 0\n            if bs_r==0 or bs_gen==0: continue\n            if real_c<n_fid: n_save_r=min(bs_r,n_fid-real_c); self._save_images_for_fid(r_b_imgs[:n_save_r],path_r,real_c,n_save_r); real_c+=n_save_r\n            if gen_c<n_fid:\n                n_gen_f=min(bs_gen,n_fid-gen_c); f_b=None\n                with torch.no_grad():\n                    if self.model_architecture==\"gan5_gcn\": z=torch.randn(n_gen_f,self.config.model.z_dim,device=self.device); f_b=self.G(z,r_b_imgs[:n_gen_f].to(self.device),seg_m[:n_gen_f],adj_m[:n_gen_f])\n                    elif self.model_architecture==\"gan6_gat_cnn\": s_g=g_b_pyg[:n_gen_f]; z_g=self.E(s_g); f_b=self.G(z_g,n_gen_f)\n                if f_b is not None: self._save_images_for_fid(f_b,path_f,gen_c,f_b.size(0)); gen_c+=f_b.size(0)\n            if real_c>=n_fid and gen_c>=n_fid: break\n        fid_v=float('nan'); min_imgs=getattr(self.config,\"fid_min_images\",10)\n        if gen_c>=min_imgs and real_c>=min_imgs:\n            try: fid_v=calculate_fid_given_paths([path_r,path_f],self.config.fid_batch_size,self.device,2048,getattr(self.config,'num_workers',0)); print(f\"FID ({data_split_for_reals},{gen_c}f,{real_c}r): {fid_v:.4f}\")\n            except Exception as e: print(f\"FID Error: {e}\")\n        else: print(f\"FID Skip: Need >={min_imgs}. Got {gen_c}f,{real_c}r.\")\n        self.G.train(om_g);self.D.train(om_d);\n        if self.E and om_e is not None:self.E.train(om_e)\n        return fid_v\n\n    def train(self):\n        print(\"Starting training (using main Trainer from src.trainer)...\")\n        eval_freq = getattr(self.config, \"eval_freq_epoch\", 1)\n        fid_freq = getattr(self.config, \"fid_freq_epoch\", 10)\n\n        for epoch_idx in range(self.current_epoch, self.config.num_epochs):\n            self.current_epoch = epoch_idx \n            self.train_epoch() \n\n            if epoch_idx % eval_freq == 0:\n                if hasattr(self.config, 'dataset_path_val') and self.config.dataset_path_val:\n                    val_metrics = self._evaluate_on_split(\"val\")\n                    if val_metrics: log_to_wandb(self.wandb_run, val_metrics, step=self.current_step)\n                if hasattr(self.config, 'dataset_path_test') and self.config.dataset_path_test:\n                    test_metrics = self._evaluate_on_split(\"test\")\n                    if test_metrics: log_to_wandb(self.wandb_run, test_metrics, step=self.current_step)\n\n            if epoch_idx % self.config.sample_freq_epoch == 0:\n                self.generate_samples(epoch_idx, self.current_step)\n\n            if getattr(self.config, 'enable_fid_calculation', False) and \\\n               (epoch_idx > 0 and (epoch_idx % fid_freq == 0 or epoch_idx == self.config.num_epochs - 1)):\n                fid_reals_split = \"test\" if hasattr(self.config, 'dataset_path_test') and self.config.dataset_path_test else \"train\"\n                temp_fid_dl = get_dataloader(self.config, data_split=fid_reals_split, shuffle=False, drop_last=False)\n                if temp_fid_dl is not None:\n                    fid_score = self.calculate_fid_score(data_split_for_reals=fid_reals_split)\n                    if not np.isnan(fid_score):\n                        log_to_wandb(self.wandb_run, {f\"FID_Score_{fid_reals_split.capitalize()}\": fid_score, \"Epoch_Num\": epoch_idx}, step=self.current_step)\n                else:\n                    print(f\"Skipping FID calculation: Dataloader for '{fid_reals_split}' could not be created.\")\n            \n            if epoch_idx % self.config.checkpoint_freq_epoch == 0 or epoch_idx == self.config.num_epochs - 1:\n                cp_data = {'epoch': epoch_idx, 'step': self.current_step,\n                           'G_state_dict': self.G.state_dict(), 'D_state_dict': self.D.state_dict(),\n                           'optG_state_dict': self.optG.state_dict(), 'optD_state_dict': self.optD.state_dict()}\n                if dataclasses.is_dataclass(self.config): cp_data['config'] = dataclasses.asdict(self.config)\n                else: cp_data['config'] = self.config \n                if self.model_architecture == \"gan6_gat_cnn\" and self.E and self.optE:\n                    cp_data['E_state_dict'] = self.E.state_dict(); cp_data['optE_state_dict'] = self.optE.state_dict()\n                save_checkpoint(cp_data, False, os.path.join(self.checkpoints_dir, f\"ckpt_ep{epoch_idx:04d}.pth.tar\"))\n                print(f\"Checkpoint saved for epoch {epoch_idx}\")\n\n        print(\"Training finished.\")\n        if self.wandb_run: self.wandb_run.finish()\n\n```


### PR DESCRIPTION
- Centralized Trainer logic in `src/trainer.py`, removing the local Trainer definition from `scripts/train.py`.
- `scripts/train.py` now acts as a simple entry point, importing and running the Trainer from `src/trainer.py`.
- Integrated gradient accumulation logic into `src/trainer.py`.
- `src/data_loader.py` updated to support `data_split` for loading train, validation, and test sets, and uses split-specific caching.
- `src/trainer.py` now includes:
    - Evaluation on validation and test splits (`_evaluate_on_split` method).
    - FID calculation on specified data splits (defaulting to test set).
    - Logging of W&B Tables for side-by-side comparison of real vs. generated images.
    - More robust handling of PyTorch Geometric Batch objects (list vs. tuple issue).
- Ensured that all new logging functionalities (metrics for different splits, FID scores per split, image comparison tables) are active.