### PR TITLE
Add experiment execution script, WandB sweep templates, and analysis …

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,109 @@
+# Generating Thesis Materials from WandB Runs
+
+This project logs comprehensive information to Weights & Biases (WandB), which can be directly used to generate tables, plots, and qualitative results for your thesis.
+
+## 1. Accessing WandB Runs
+
+*   Navigate to your WandB project page (e.g., `SuperpixelGAN_Refactored` or `SuperpixelGAN_Sweeps`).
+*   You will see a list of all your runs, including those from `scripts/run_experiments.py` and any hyperparameter sweeps.
+
+## 2. Key Information Logged
+
+For each run, the following crucial information should be available in the WandB dashboard:
+
+*   **Hyperparameters:** The "Overview" tab or a dedicated "Config" section for each run lists all hyperparameters used for that run (from your YAML configs and any overrides). This is essential for documenting your experimental setup.
+*   **Metrics over Time (Learning Curves):**
+    *   Generator Losses (e.g., `train/Loss_G`, `val/Loss_G`)
+    *   Discriminator Losses (e.g., `train/Loss_D`, `val/Loss_D_Adv`, `val/Loss_D_R1`)
+    *   Feature Matching Losses (for ProjectedGAN, e.g., `train/Loss_G_FeatMatch`)
+    *   Mean Discriminator Logits (e.g., `val/D_Real_Logits_Mean`, `val/D_Fake_Logits_Mean`)
+    *   These are available in the "Charts" tab. You can customize plots, smooth lines, and compare multiple runs.
+*   **FID Scores:**
+    *   Fréchet Inception Distance scores (e.g., `val/FID_Score`) are logged if `enable_fid_calculation=True`. These are critical for quantitative comparison of model quality.
+    *   You can view these in the "Charts" tab or create a summary table (see below).
+*   **Generated Image Samples:**
+    *   Image samples logged during training (e.g., `val/Generated_Samples`) can be found in the "Media" tab. These are vital for qualitative assessment. You can typically view them individually or as a panel, and download them.
+*   **System Metrics:** WandB also logs GPU/CPU utilization, memory, etc., which might be relevant for discussing computational aspects.
+
+## 3. Generating Materials for Thesis
+
+### A. Tables
+
+*   **Hyperparameter Tables:**
+    *   Use the "Config" section in WandB for each run to manually create tables summarizing the key hyperparameters for different models or ablation studies.
+*   **Quantitative Results Table (e.g., FID Scores):**
+    1.  In the WandB project view, you can add columns to the runs table to display summary metrics like the minimum `val/FID_Score` achieved by each run.
+    2.  Select the runs you want to compare (e.g., all "standard" runs for each architecture, or a model vs. its ablation).
+    3.  Customize the columns to show: Run Name, Model Architecture (from config), Key Ablation Flags (from config), and the final or best FID score.
+    4.  You can then export this table view as a CSV or take a screenshot.
+    *Example Table Structure:*
+    | Run Name                          | Architecture   | Ablation Details             | Best FID Score (val) |
+    |-----------------------------------|----------------|------------------------------|----------------------|
+    | `gan5_gcn_standard`               | `gan5_gcn`     | GCN Enabled                  | XX.XX                |
+    | `gan5_gcn_ablation_no_gcn`        | `gan5_gcn`     | GCN Disabled                 | YY.YY                |
+    | `stylegan2_standard_no_sp_cond` | `stylegan2`    | No Superpixel Cond.        | AA.AA                |
+    | `stylegan2_conditioned_sp`      | `stylegan2`    | Superpixel Cond. Enabled   | BB.BB                |
+    | ...                               | ...            | ...                          | ...                  |
+
+### B. Plots (Learning Curves)
+
+*   **Individual Run Analysis:**
+    *   Go to a specific run in WandB.
+    *   The "Charts" tab will show plots of all logged metrics over training steps/epochs.
+    *   Customize these plots (e.g., add smoothing, change x-axis, focus on specific metrics like `val/Loss_G` or `val/FID_Score`).
+    *   You can download these plots as PNG images directly from the WandB UI.
+*   **Comparing Multiple Runs:**
+    1.  From the project page, select multiple runs you want to compare.
+    2.  Click "Group" if runs are not already grouped by a common characteristic (like architecture).
+    3.  Go to the "Charts" panel. You can plot metrics from all selected runs on the same graph. For example, plot `val/FID_Score` for `stylegan2_standard` vs. `stylegan2_conditioned_sp`.
+    4.  Customize and download these comparison plots.
+
+### C. Qualitative Results (Generated Images)
+
+*   **Best Samples:**
+    *   For each model/run, go to the "Media" tab in WandB.
+    *   Identify the epoch/step that produced the best looking samples (often correlates with the best FID score, but visual inspection is key).
+    *   Download these high-quality samples. You can create panels or figures in your thesis to showcase the visual quality.
+*   **Evolution of Samples:**
+    *   WandB often allows you to scroll through samples logged at different timesteps. This can be used to illustrate how image quality improves over training.
+
+### D. Hyperparameter Importance (from Sweeps)
+
+*   If you run WandB Sweeps:
+    *   The sweep results page in WandB provides plots showing parameter importance, parallel coordinate plots, and scatter plots of hyperparameters vs. the target metric (e.g., `val/FID_Score`).
+    *   These visualizations can be directly used or adapted to discuss which hyperparameters had the most impact on model performance.
+
+## 4. Using WandB API for Programmatic Access (Advanced)
+
+If you need more customized tables or plots than the WandB UI provides:
+
+*   **Install WandB library:** `pip install wandb`
+*   **Use the API:** You can write Python scripts to fetch run data (configs, summary metrics, metric history) and then process it using libraries like Pandas (for tables) and Matplotlib/Seaborn (for plots).
+
+```python
+# Example: Fetching FID scores for selected runs
+import wandb
+api = wandb.Api()
+
+# Replace with your entity, project, and desired run IDs or filters
+runs = api.runs("YOUR_ENTITY/YOUR_PROJECT_NAME", filters={
+    # "display_name": {"$regex": ".*standard.*"} # Example filter
+})
+
+fid_data = []
+for run in runs:
+    if "val/FID_Score" in run.summary: # Check if FID was logged
+        fid_data.append({
+            "run_name": run.name,
+            "architecture": run.config.get("model", {}).get("architecture"),
+            "best_fid": run.summary["val/FID_Score"] # Or min_fid if logged that way
+            # Add other relevant config values
+        })
+
+import pandas as pd
+df_fid = pd.DataFrame(fid_data)
+print(df_fid)
+# df_fid.to_csv("fid_summary.csv")
+```
+
+By leveraging these WandB features, you can efficiently gather and present the results of your experiments for your thesis. Remember to customize plots and tables to fit the specific narrative and requirements of your document.

--- a/configs/sweeps/base_for_sweeps.yaml
+++ b/configs/sweeps/base_for_sweeps.yaml
@@ -1,0 +1,106 @@
+# Base configuration settings for WandB sweeps.
+# Sweep-specific YAMLs will load this and then override/add parameters.
+
+# --- System and Paths ---
+project_name: "SuperpixelGAN_Sweeps" # WandB project for all sweeps
+# output_dir_base: "experiment_outputs_sweeps" # Optional: separate output for sweeps
+dataset_path: "/home/student2/histo/data/lung_colon_image_set/lung_image_sets/lung_scc" # CHECK THIS PATH
+cache_dir: "superpixel_cache_sweeps"
+num_workers: 2 # Reduce for sweeps if I/O is not bottleneck
+device: "cuda"
+seed: null # Allow WandB to set different seeds for different runs in a sweep
+
+# --- Data and Preprocessing ---
+image_size: 256 # Keep consistent with your target, or reduce if necessary for faster sweeps
+num_superpixels: 150 # Global default, model-specific may override
+slic_compactness: 10.0
+debug_num_images: 0 # Use a reasonable subset for faster sweeps, e.g., 1000, or 0 for full dataset if feasible
+
+# --- Training Hyperparameters ---
+# batch_size will be set by individual sweep configs if tuned, otherwise a default here
+batch_size: 4 # Smaller batch size for sweeps to conserve memory / run faster
+num_epochs: 50 # Reduced epochs for sweeps. Adjust as needed.
+# g_lr, d_lr, beta1, beta2, r1_gamma will be tuned by the sweep typically.
+# Defaults for non-tuned optimizer params:
+beta1: 0.0
+beta2: 0.99
+r1_gamma: 5.0 # Default, can be tuned
+d_updates_per_g_update: 1 # Often set to 1 for sweeps for speed, can be tuned
+gradient_accumulation_steps: 1
+
+# --- Logging and Evaluation ---
+use_wandb: True # Essential for sweeps
+log_freq_step: 200 # Log less frequently during sweeps
+sample_freq_epoch: 10 # Generate samples less often, or disable (0)
+num_samples_to_log: 4
+checkpoint_freq_epoch: 0 # Disable checkpointing for sweeps unless specifically needed
+enable_fid_calculation: True # Enable FID if it's the primary metric
+fid_num_images: 1000 # Reduced number for faster FID during sweeps
+fid_batch_size: 8
+fid_freq_epoch: 25 # FID less frequently
+
+# --- Model settings that are NOT tuned in this sweep file ---
+# Specific model architecture params will be in the sweep file (e.g., model.architecture)
+# or taken from base_config.py defaults if not overridden by sweep.
+
+# --- Default Model Config (can be overridden by sweep params) ---
+# It's often cleaner to let the sweep define model architecture and its params.
+# However, some base model params might be set here if they are fixed across sweeps for an arch.
+# For example, if `z_dim` is fixed for all stylegan2 sweeps:
+# model:
+#   z_dim: 256 # This is a general z_dim, stylegan2 uses model.stylegan2_z_dim
+
+# Ensure that the sweep YAMLs specify `model.architecture`
+# and other necessary fixed model parameters if not tuning them.
+# The `scripts/train.py` will load `configs.base_config.BaseConfig` first,
+# then this `base_for_sweeps.yaml` (if specified via an extended syntax in wandb sweep command),
+# and then the command line args from the sweep agent.
+# A simpler way: `scripts/train.py` just takes dot-list overrides.
+# The sweep agent provides these. `scripts/train.py` should have its own
+# default config file (e.g. `experiment_config.yaml`) or use `BaseConfig` defaults.
+# This `base_for_sweeps.yaml` is more of a reference for what settings to use
+# when running sweeps, either by pointing train.py to it or by ensuring sweep
+# parameters cover these aspects.
+
+# For the current `scripts/train.py` which takes `--config_file`, this
+# `base_for_sweeps.yaml` could be passed as that config_file argument
+# by the sweep agent if the agent command is structured like:
+# program: scripts/train.py
+# command:
+#   - ${env}
+#   - python
+#   - ${program}
+#   - "--config_file"
+#   - "configs/sweeps/base_for_sweeps.yaml" # Pass this base
+#   - ${args} # Sweep parameters as dot-list overrides
+# This way, this file sets the defaults for the sweep runs.
+
+# Default model section (can be sparse, sweep params will fill it)
+model:
+  # Superpixel conditioning settings - can be tuned or fixed for a sweep series
+  use_superpixel_conditioning: False
+  superpixel_latent_encoder_enabled: False
+  # Defaults for conditioning params if enabled by a sweep
+  superpixel_spatial_map_channels_g: 1
+  superpixel_spatial_map_channels_d: 1
+  superpixel_feature_dim: 3
+  superpixel_latent_encoder_hidden_dims: [64, 128]
+  superpixel_latent_embedding_dim: 128
+  # Specific model conditioning flags (e.g., model.stylegan2_g_spatial_cond)
+  # would be set to False here by default, and sweep can try to turn them True.
+  dcgan_g_spatial_cond: False
+  dcgan_g_latent_cond: False
+  dcgan_d_spatial_cond: False
+  stylegan2_g_spatial_cond: False
+  stylegan2_g_latent_cond: False
+  stylegan2_d_spatial_cond: False
+  stylegan3_g_spatial_cond: False
+  stylegan3_g_latent_cond: False
+  stylegan3_d_spatial_cond: False
+  projectedgan_d_spatial_cond: False
+  # For projected GAN, G conditioning is via stylegan2 flags, so covered above.
+  # gan5/gan6 specific ablation flags
+  gan5_gcn_disable_gcn_blocks: False
+  gan6_gat_cnn_use_null_graph_embedding: False
+  projectedgan_feature_matching_loss_weight: 10.0 # Example default, can be tuned
+  projectedgan_feature_extractor_name: "resnet50"

--- a/configs/sweeps/gan6_sweep.yaml
+++ b/configs/sweeps/gan6_sweep.yaml
@@ -1,0 +1,84 @@
+# WandB Sweep Configuration for gan6_gat_cnn
+
+program: scripts/train.py # Path to your training script
+
+method: bayes
+
+metric:
+  name: "val/FID_Score" # Or "val/Loss_G", "val/Loss_D_Adv" etc.
+  goal: minimize
+
+parameters:
+  # --- Fixed parameters for this sweep series ---
+  model.architecture:
+    value: "gan6_gat_cnn"
+
+  # For gan6_gat_cnn, superpixel processing is intrinsic to its ImageToGraphDataset.
+  # The `model.use_superpixel_conditioning` flag is less relevant for its core mechanism.
+  # Ablation of graph component is done via `model.gan6_gat_cnn_use_null_graph_embedding`
+  # which can also be part of a sweep if desired.
+  # model.gan6_gat_cnn_use_null_graph_embedding:
+  #  values: [True, False]
+
+
+  # --- Hyperparameters to Tune ---
+  g_lr: # Learning rate for Generator (and Encoder in current gan6 setup)
+    distribution: log_uniform_values
+    min: 1e-6
+    max: 1e-3
+
+  d_lr: # Learning rate for Discriminator
+    distribution: log_uniform_values
+    min: 1e-6
+    max: 1e-3
+
+  r1_gamma:
+    distribution: uniform
+    min: 1.0
+    max: 10.0
+
+  # GAT Encoder parameters
+  model.gat_dim:
+    values: [64, 128, 256]
+  model.gat_heads:
+    values: [2, 4, 8]
+  model.gat_layers:
+    values: [2, 3, 4]
+  # model.gat_dropout: # If implemented and used in GAT
+  #   distribution: uniform
+  #   min: 0.0
+  #   max: 0.3
+
+  model.gan6_z_dim_graph_encoder_output: # Output of GAT encoder
+    values: [64, 128, 256]
+
+  # CNN Generator parameters (conditioned on GAT output + noise)
+  model.gan6_z_dim_noise: # Noise vector concatenated with graph embedding
+    values: [64, 128, 256]
+  # model.gan6_gen_init_size: # Usually fixed based on architecture, e.g., 4
+  #   value: 4
+  model.gan6_gen_feat_start: # Channels in the first layer of G_cnn
+    values: [256, 512]
+
+  # CNN Discriminator parameters
+  model.gan6_d_feat_start: # Channels in the first layer of D_cnn
+    values: [32, 64, 128]
+  # model.gan6_d_final_conv_size: # Usually fixed, e.g., 16
+  #   value: 16
+
+  # Optional: Spectral norm toggles (if they make a big difference and are uncertain)
+  # model.gan6_gen_spectral_norm:
+  #   values: [True, False]
+  # model.gan6_d_spectral_norm:
+  #   values: [True, False]
+  # model.gan6_d_spectral_norm_fc:
+  #   values: [True, False]
+
+# Command template for the agent to run
+command:
+  - ${env}
+  - ${interpreter}
+  - ${program}
+  - "--config_file"
+  - "configs/sweeps/base_for_sweeps.yaml" # Base settings for the sweep runs
+  - ${args}

--- a/configs/sweeps/stylegan2_sweep.yaml
+++ b/configs/sweeps/stylegan2_sweep.yaml
@@ -1,0 +1,94 @@
+# WandB Sweep Configuration for StyleGAN2
+
+program: scripts/train.py # Path to your training script
+
+method: bayes # Bayesian optimization
+
+metric:
+  name: "val/FID_Score" # Primary metric to optimize. Ensure Trainer logs this.
+                        # Or use "val/Loss_G" or other relevant metric.
+  goal: minimize
+
+# Early termination configuration (optional, but recommended for long sweeps)
+# early_terminate:
+#   type: hyperband
+#   min_iter: 10 # Minimum number of epochs/iterations before a run can be stopped.
+#   # s: 2 # Number of brackets. Adjust based on total resources.
+
+parameters:
+  # --- Command structure to use base_for_sweeps.yaml ---
+  # This tells wandb agent how to construct the command.
+  # It will call: python scripts/train.py --config_file configs/sweeps/base_for_sweeps.yaml model.architecture=stylegan2 g_lr=...
+  # This relies on OmegaConf's ability to merge a base YAML with dot-list overrides.
+  # The `train.py` script loads the --config_file, then OmegaConf applies CLI overrides.
+
+  # --- Fixed parameters for this sweep series ---
+  model.architecture:
+    value: "stylegan2"
+
+  # --- Hyperparameters to Tune ---
+  g_lr:
+    distribution: log_uniform_values
+    min: 1e-6
+    max: 1e-3
+
+  d_lr:
+    distribution: log_uniform_values
+    min: 1e-6
+    max: 1e-3
+
+  # Adam betas (can be tuned if desired, or kept fixed from base_for_sweeps.yaml)
+  # beta1:
+  #   distribution: uniform
+  #   min: 0.0
+  #   max: 0.5
+  # beta2:
+  #   distribution: uniform
+  #   min: 0.9
+  #   max: 0.999
+
+  r1_gamma:
+    distribution: uniform
+    min: 0.1 # R1 gamma can be sensitive. For StyleGAN2, often 1-10.
+    max: 20.0
+
+  model.stylegan2_channel_multiplier:
+    values: [1, 2] # Affects model size significantly
+
+  model.stylegan2_n_mlp:
+    values: [4, 6, 8] # Depth of the mapping network
+
+  # model.stylegan2_z_dim: # Usually fixed, but could be tuned
+  #   values: [256, 512]
+  # model.stylegan2_w_dim: # Usually fixed, but could be tuned
+  #   values: [256, 512]
+
+  # Optional: Tune batch_size if resources allow.
+  # batch_size:
+  #   values: [2, 4, 8] # Be mindful of GPU memory
+
+  # Optional: Tune superpixel conditioning for StyleGAN2
+  # model.use_superpixel_conditioning:
+  #   values: [True, False] # If True, enable specific conditioning types below
+  # model.stylegan2_g_spatial_cond: # Only effective if use_superpixel_conditioning is True
+  #   values: [True, False]
+  # model.stylegan2_d_spatial_cond: # Only effective if use_superpixel_conditioning is True
+  #   values: [True, False]
+  # model.stylegan2_g_latent_cond: # Only effective if use_superpixel_conditioning is True
+  #   values: [True, False]
+  # model.superpixel_latent_encoder_enabled: # Only effective if g_latent_cond is True
+  #   values: [True, False]
+
+
+# Command template for the agent to run.
+# `${env}` sets up environment variables (like WANDB_API_KEY).
+# `${interpreter}` is usually `python`.
+# `${program}` is `scripts/train.py`.
+# `${args}` are the hyperparameter overrides like `g_lr=0.001 model.architecture=stylegan2 ...`.
+command:
+  - ${env}
+  - ${interpreter}
+  - ${program}
+  - "--config_file"
+  - "configs/sweeps/base_for_sweeps.yaml" # Base settings for the sweep runs
+  - ${args}

--- a/scripts/run_experiments.py
+++ b/scripts/run_experiments.py
@@ -1,0 +1,200 @@
+import subprocess
+import tempfile
+import os
+from omegaconf import OmegaConf, DictConfig
+
+# Assuming BaseConfig is importable and structured appropriately
+# Add paths for local imports if necessary, or ensure your PYTHONPATH is set
+try:
+    from configs.base_config import BaseConfig, ModelConfig
+except ModuleNotFoundError:
+    # Simple fallback if running script directly and paths aren't set up
+    # This might require adjusting if your BaseConfig has complex dependencies at import time
+    import sys
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+    from configs.base_config import BaseConfig, ModelConfig
+
+def get_experiment_configurations() -> list[dict]:
+    """
+    Defines a list of experiment configurations to run.
+    Each configuration is a dictionary with:
+        - name: A descriptive name for the experiment.
+        - model_architecture: The architecture to use.
+        - run_name_suffix: Suffix for WandB run name.
+        - config_overrides: Dictionary of OmegaConf dot-paths and values to override.
+    """
+    experiments = []
+    base_architectures = ["gan5_gcn", "gan6_gat_cnn", "dcgan", "stylegan2", "projectedgan", "stylegan3"]
+
+    for arch in base_architectures:
+        # --- Standard Run (Superpixel Conditioning Disabled, or native if model requires it) ---
+        std_overrides = {
+            "model.architecture": arch,
+            "model.use_superpixel_conditioning": False, # Default to off for non-superpixel native models
+            "run_name": f"{arch}_standard_no_sp_cond",
+             # Reduce epochs for faster testing of the script itself. User should increase for real runs.
+            "num_epochs": 2, # TODO: Remove or increase for actual experiments
+            "debug_num_images": 16, # TODO: Remove or increase for actual experiments
+            "batch_size": 2, # TODO: Remove or increase
+            "enable_fid_calculation": False, # Disable FID for faster script testing
+        }
+
+        if arch == "gan5_gcn":
+            # gan5_gcn inherently uses superpixels, so 'use_superpixel_conditioning' doesn't gate its core mechanism.
+            # Its "standard" run is just its default behavior.
+            std_overrides["run_name"] = f"{arch}_standard"
+            std_overrides["model.gan5_gcn_disable_gcn_blocks"] = False
+            # No need to set model.use_superpixel_conditioning for gan5/gan6 as their dataloaders
+            # are intrinsically superpixel-based. The flag is more for add-on conditioning.
+        elif arch == "gan6_gat_cnn":
+            std_overrides["run_name"] = f"{arch}_standard"
+            std_overrides["model.gan6_gat_cnn_use_null_graph_embedding"] = False
+
+        experiments.append({
+            "name": f"{arch}_Standard",
+            "model_architecture": arch,
+            "config_overrides": std_overrides.copy()
+        })
+
+        # --- Ablation Runs / Superpixel Conditioned Runs ---
+        ablation_overrides = std_overrides.copy() # Start from standard settings
+
+        if arch == "gan5_gcn":
+            ablation_overrides["model.gan5_gcn_disable_gcn_blocks"] = True
+            ablation_overrides["run_name"] = f"{arch}_ablation_no_gcn"
+            experiments.append({
+                "name": f"{arch}_Ablation_NoGCN",
+                "model_architecture": arch,
+                "config_overrides": ablation_overrides
+            })
+        elif arch == "gan6_gat_cnn":
+            ablation_overrides["model.gan6_gat_cnn_use_null_graph_embedding"] = True
+            ablation_overrides["run_name"] = f"{arch}_ablation_null_graph_embed"
+            experiments.append({
+                "name": f"{arch}_Ablation_NullGraphEmbedding",
+                "model_architecture": arch,
+                "config_overrides": ablation_overrides
+            })
+        else: # For DCGAN, StyleGAN2, StyleGAN3, ProjectedGAN - "ablation" is enabling superpixel conditioning
+            # These are models where superpixel conditioning is an add-on.
+            # The "standard" run defined above has model.use_superpixel_conditioning=False.
+            # This "conditioned" run will enable it.
+            cond_overrides = std_overrides.copy()
+            cond_overrides["model.use_superpixel_conditioning"] = True
+            cond_overrides["run_name"] = f"{arch}_conditioned_sp_spatial_latent" # Example name
+
+            # Enable specific conditioning types for these models (can be fine-tuned)
+            # C1: Spatial G, C4: Spatial D, C2: Latent G
+            # Ensure model config has these flags: e.g. model.dcgan_g_spatial_cond
+            cond_overrides[f"model.{arch}_g_spatial_cond"] = True
+            cond_overrides[f"model.{arch}_d_spatial_cond"] = True
+            cond_overrides[f"model.{arch}_g_latent_cond"] = True # Requires sp_latent_encoder
+            cond_overrides["model.superpixel_latent_encoder_enabled"] = True # Enable the encoder itself
+
+            # Special handling for ProjectedGAN D conditioning (doesn't have g_latent_cond at G level like others)
+            if arch == "projectedgan":
+                 cond_overrides[f"model.stylegan2_g_spatial_cond"] = True # PG G is StyleGAN2
+                 cond_overrides[f"model.stylegan2_g_latent_cond"] = True
+                 cond_overrides[f"model.projectedgan_d_spatial_cond"] = True
+                 # Remove generic arch flags if they don't exist for projectedgan directly
+                 cond_overrides.pop(f"model.{arch}_g_spatial_cond", None)
+                 cond_overrides.pop(f"model.{arch}_g_latent_cond", None)
+
+
+            experiments.append({
+                "name": f"{arch}_Conditioned_Superpixel",
+                "model_architecture": arch,
+                "config_overrides": cond_overrides
+            })
+
+    return experiments
+
+def run_single_experiment(exp_config: dict, base_cfg_obj: OmegaConf):
+    """Runs a single experiment using scripts/train.py."""
+    print(f"\n{'='*30}\nRunning Experiment: {exp_config['name']}\n{'='*30}")
+
+    # Create a mutable copy of the base config
+    conf = base_cfg_obj.copy() # type: ignore
+
+    # Apply overrides
+    for key, value in exp_config["config_overrides"].items():
+        OmegaConf.update(conf, key, value) # type: ignore
+
+    # Ensure essential settings for the run
+    conf.use_wandb = True # Force WandB for these experiments
+    # run_name should be set by overrides, but double check
+    if "run_name" not in exp_config["config_overrides"]:
+        print(f"Warning: 'run_name' not in overrides for {exp_config['name']}. Using default.")
+        conf.run_name = exp_config['name'].replace(" ", "_").lower()
+    else:
+        conf.run_name = exp_config['config_overrides']['run_name']
+
+
+    # Create a temporary YAML file for this specific configuration
+    # tempfile.NamedTemporaryFile creates a file that is deleted when closed.
+    # We need to pass the filename to subprocess, so we manage it manually.
+    temp_dir = tempfile.mkdtemp()
+    temp_config_path = os.path.join(temp_dir, "temp_experiment_config.yaml")
+
+    try:
+        OmegaConf.save(config=conf, f=temp_config_path)
+        print(f"Saved temporary config for {exp_config['name']} to {temp_config_path}")
+        print(f"Final configuration for this run ({conf.run_name}):")
+        # print(OmegaConf.to_yaml(conf)) # Can be verbose
+
+        # Construct and run the training command
+        # Ensure train.py is executable or called via python -m
+        # Using python -m is generally more robust for module resolution
+        command = [
+            "python", "-m", "scripts.train",
+            "--config_file", temp_config_path
+        ]
+        print(f"Executing command: {' '.join(command)}")
+
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+        # Stream output
+        if process.stdout:
+            for line in iter(process.stdout.readline, ''):
+                print(line, end='')
+
+        process.wait() # Wait for the subprocess to complete
+
+        if process.returncode == 0:
+            print(f"Experiment {exp_config['name']} (Run: {conf.run_name}) completed successfully.")
+        else:
+            print(f"Error: Experiment {exp_config['name']} (Run: {conf.run_name}) failed with return code {process.returncode}.")
+
+    except Exception as e:
+        print(f"An error occurred while setting up or running experiment {exp_config['name']}: {e}")
+    finally:
+        # Clean up the temporary file and directory
+        if os.path.exists(temp_config_path):
+            os.remove(temp_config_path)
+        if os.path.exists(temp_dir):
+            os.rmdir(temp_dir)
+        print(f"Cleaned up temporary config for {exp_config['name']}.")
+
+
+def main():
+    print("Starting batch of GAN experiments...")
+    experiments_to_run = get_experiment_configurations()
+    print(f"Found {len(experiments_to_run)} experiment configurations to run.")
+
+    # Load the structured base configuration once
+    # This ensures that any defaults or type hints from BaseConfig are respected
+    # before overrides are applied.
+    base_omega_conf = OmegaConf.structured(BaseConfig)
+
+    for i, exp_conf in enumerate(experiments_to_run):
+        print(f"\n--- Progress: Experiment {i+1} / {len(experiments_to_run)} ---")
+        run_single_experiment(exp_conf, base_omega_conf) # type: ignore
+
+    print("\nAll scheduled experiments have been attempted.")
+    print("Please check WandB for detailed results and logs.")
+
+if __name__ == "__main__":
+    # Ensure the script is run from the root of the repository for imports to work correctly
+    # or adjust PYTHONPATH.
+    # Example: python -m scripts.run_experiments
+    main()


### PR DESCRIPTION
…guide

- Created `scripts/run_experiments.py` to automate running various GAN architectures with standard and ablation/conditioned configurations.
- Added WandB sweep YAML templates for `stylegan2` and `gan6_gat_cnn`, along with a base configuration for sweeps.
- Created `ANALYSIS.md` to guide users on extracting data from WandB for thesis presentation.